### PR TITLE
list: Pretty print entities list

### DIFF
--- a/homeassistant_cli/cli.py
+++ b/homeassistant_cli/cli.py
@@ -66,3 +66,6 @@ def cli(ctx, verbose, host, password, ssl, port):
         ctx.log("Your API password for %s was not provided or is wrong. "
                 "Use '--password/-p'", ctx.host)
         sys.exit(1)
+
+if __name__  == '__main__':
+    cli()

--- a/homeassistant_cli/plugins/info.py
+++ b/homeassistant_cli/plugins/info.py
@@ -1,11 +1,12 @@
 """Configuration plugin for Home Assistant CLI (hass-cli)."""
 import webbrowser
 import urllib.parse
+from collections import namedtuple
 
 import click
 
 from homeassistant_cli.cli import pass_context
-from homeassistant_cli.helper import json_output, timestamp, req
+from homeassistant_cli.helper import timestamp
 
 OSM_URL = 'https://www.openstreetmap.org'
 ZOOM = 17
@@ -20,7 +21,7 @@ def cli(ctx, location, connect):
     config = remote.get_config(ctx.api)
 
     if not location and not connect:
-        ctx.log(json_output(config))
+        ctx.log(format_config(config))
         ctx.vlog('Details of %s, Recieved: %s', ctx.host, timestamp())
 
     if location and not connect:
@@ -32,3 +33,27 @@ def cli(ctx, location, connect):
         url = 'http://{}:{}'.format(ctx.host, ctx.port)
         webbrowser.open_new_tab(url)
 
+def format_config(config):
+    UnitSystem = namedtuple('UnitSystem', ['mass', 'volume', 'distance', 'temperature'])
+    units = namedtuple('UnitSystem', config.get('unit_system').keys())(**config.get('unit_system'))
+    format_arguments = {
+            **config,
+            'whitelist_external_dirs': ', '.join(config.get('whitelist_external_dirs')),
+            'units': units,
+            'components': ', '.join(sorted(config.get('components'))),
+            }
+    return """
+Location name:                      {location_name}
+Version:                            {version}
+Location:                           {latitude}°, {longitude}°
+Elevation:                          {elevation}{units.length}
+Timezone:                           {time_zone}
+Whitelisted external directories:   {whitelist_external_dirs}
+Config dir:                         {config_dir}
+Units:
+    Mass:                           {units.mass}
+    Volume:                         {units.volume}
+    Distance:                       {units.length}
+    Temperature:                    {units.temperature}
+Components:                         {components}
+    """.strip().format(**format_arguments)

--- a/homeassistant_cli/plugins/info.py
+++ b/homeassistant_cli/plugins/info.py
@@ -6,7 +6,6 @@ import click
 
 from homeassistant_cli.cli import pass_context
 from homeassistant_cli.helper import json_output, timestamp, req
-from homeassistant_cli.const import DEFAULT_PORT
 
 OSM_URL = 'https://www.openstreetmap.org'
 ZOOM = 17
@@ -30,6 +29,6 @@ def cli(ctx, location, connect):
         webbrowser.open_new_tab(url)
 
     if connect and not location:
-        url = 'http://{}:{}'.format(ctx.host, DEFAULT_PORT)
+        url = 'http://{}:{}'.format(ctx.host, ctx.port)
         webbrowser.open_new_tab(url)
 

--- a/homeassistant_cli/plugins/list.py
+++ b/homeassistant_cli/plugins/list.py
@@ -1,5 +1,6 @@
 """List plugin for Home Assistant CLI (hass-cli)."""
 import click
+from homeassistant.core import State
 
 from homeassistant_cli.cli import pass_context
 from homeassistant_cli.helper import json_output, timestamp
@@ -8,8 +9,11 @@ from homeassistant_cli.helper import json_output, timestamp
 @click.option('--entry', '-e',
               type=click.Choice(['services', 'events', 'entities']),
               help='The entry to list.')
+@click.option('--show-all',
+              is_flag=True,
+              help='Show all attributes')
 @pass_context
-def cli(ctx, entry):
+def cli(ctx, entry, show_all):
     """List various entries of an instance."""
     import homeassistant.remote as remote
 
@@ -26,7 +30,61 @@ def cli(ctx, entry):
 
     if entry == 'entities':
         entities = remote.get_states(ctx.api)
-        for entity in entities:
-            ctx.log(entity)
+        for row in EntityFormatter(entities, show_all).get_rows():
+            ctx.log(row)
 
     ctx.vlog('Details of %s, Created: %s', ctx.host, timestamp())
+
+
+class EntityFormatter:
+    def __init__(self, entities, show_all_attributes):
+        self.rows = list(map(EntityFormatter._extract_fields, entities))
+        self.entity_format = self._build_entity_format(show_all_attributes)
+        self.field_widths = self._get_output_widths()
+
+    @staticmethod
+    def _build_entity_format(show_all_attributes):
+        entity_format = "{name:<{name_length}}" \
+                             "{entity_id:<{entity_id_length}}" \
+                             "{state:<{state_length}}"
+        if show_all_attributes:
+            entity_format += "{attributes:<{attributes_length}}"
+        return entity_format + "{last_changed:<{last_changed_length}}"
+
+    @staticmethod
+    def _extract_fields(entity: State):
+        def format_attributes(attributes):
+            formatted_attributes = ["%s=%s" % (key, item) for key, item in
+                                    attributes.items() if key not in ['friendly_name']]
+            return ", ".join(formatted_attributes)
+
+        return {
+            'name': entity.name,
+            'entity_id': entity.entity_id,
+            'state': entity.state,
+            'last_changed': entity.last_changed.isoformat(),
+            'attributes': format_attributes(entity.attributes)
+        }
+
+    def _get_output_widths(self):
+        return {field + '_length': max_length + 3 for (field, max_length) in
+                self._get_column_widths().items()}
+
+    def _get_column_widths(self):
+        longest = {}
+        for row in self.rows:
+            for (field, value) in (row.items()):
+                longest[field] = max(longest.get(field, 0), len(value))
+        return longest
+
+    def _format_row(self, **kwargs):
+        return self.entity_format.format(**kwargs, **self.field_widths)
+
+    def get_rows(self):
+        header = [self._format_row(
+            name='Name',
+            entity_id='Identifier',
+            state='State',
+            last_changed='Last change',
+            attributes='Additional attributes')]
+        return header + list(map(lambda row: self._format_row(**row), self.rows))


### PR DESCRIPTION
I'm very curious what you think about this PR.

I was not very sure about the output format, so I just made it columnar. This is _very_ difficult to parse from scripts (since whitespace is used inside the columns as well as between them), however I'm not yet sure how to deal with that properly (using null terminators is probably the most sensible, as with `find -print0`)

Moreover we probably want to pretty-print the other list entries, however I'm what would be useful in those lists.

A future improvement is probably to split the commands further as the `--show-all` argument currently only applies to entities. What I'm imagining is:

    $ hass-cli list entities
    $ hass-cli list entities --show-all
    $ hass-cli list services