### PR TITLE
Hass.io compatibility #23

### DIFF
--- a/homeassistant_cli/const.py
+++ b/homeassistant_cli/const.py
@@ -6,5 +6,6 @@ __version__ = '0.2.0.dev'
 REQUIRED_PYTHON_VER = (3, 5, 3)
 
 DEFAULT_SERVER = 'http://localhost:8123'
+DEFAULT_HASSIO_SERVER = 'http://hassio/homeassistant'
 DEFAULT_TIMEOUT = 5
 DEFAULT_OUTPUT = 'json'  # TODO: Have default be human table relevant output

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,0 +1,49 @@
+"""Tests file for Home Assistant CLI (hass-cli)."""
+import os
+
+import homeassistant_cli.cli as cli
+from homeassistant_cli.config import Configuration
+from unittest import mock
+import pytest
+
+HASSIO_SERVER_FALLBACK = "http://hassio/homeassistant"
+HASS_SERVER = "http://localhost:8123"
+
+
+@pytest.mark.parametrize("description,env,expected_server,expected_token", [
+   ("No env set, all should be defaults",
+    {},
+    HASS_SERVER,
+    None),
+   ("If only HASSIO_TOKEN, use default hassio",
+    {'HASSIO_TOKEN': 'supersecret'},
+    HASSIO_SERVER_FALLBACK, "supersecret"),
+   ("Honor HASS_SERVER together with HASSIO_TOKEN",
+    {'HASSIO_TOKEN': 'supersecret',
+     'HASS_SERVER': 'http://localhost:999999'},
+    "http://localhost:999999", "supersecret"),
+   ("HASS_TOKEN should win over HASIO_TOKEN",
+    {'HASSIO_TOKEN': 'supersecret',
+     'HASS_TOKEN': 'I Win!'},
+    HASS_SERVER, 'I Win!'),
+])
+def test_defaults(description, env, expected_server, expected_token):
+
+    mockenv = mock.patch.dict(os.environ,
+                              env)
+
+    try:
+        mockenv.start()
+        ctx = cli.cli.make_context('hass-cli', ['--timeout', '1', 'info'])
+        with ctx:
+            try:
+                cli.cli.invoke(ctx)
+            except Exception:
+                pass
+
+        cfg: Configuration = ctx.obj
+
+        assert cfg.server == expected_server
+        assert cfg.token == expected_token
+    finally:
+        mockenv.stop()


### PR DESCRIPTION
Why:

 * would be nice if you are using standard HASSIO_TOKEN that we will
   default to hassio.local server instead of localhost

This change addreses the need by:

 * As suggested in #23 we'll use hassio.local if HASSIO_TOKEN is
   available and no HASS_TOKEN active.