### PR TITLE
Add --insecure flag to allow self-signed certs

### DIFF
--- a/homeassistant_cli/cli.py
+++ b/homeassistant_cli/cli.py
@@ -99,10 +99,15 @@ class HomeAssistantCli(click.MultiCommand):
               default='json', show_default=True)
 @click.option('-v', '--verbose', is_flag=True,
               help='Enables verbose mode.')
+@click.option('--insecure', is_flag=True, default=False,
+              help=('Ignore SSL Certificates.'
+                    ' Allow to connect to servers with'
+                    ' self-signed certificates.'
+                    ' Be careful!'))
 @click.option('--debug', is_flag=True, default=False,
               help='Enables debug mode.')
 @pass_context
-def cli(ctx, verbose, server, token, output, timeout, debug):
+def cli(ctx, verbose, server, token, output, timeout, debug, insecure):
     """Command line interface for Home Assistant."""
     ctx.verbose = verbose
     ctx.server = server
@@ -110,6 +115,7 @@ def cli(ctx, verbose, server, token, output, timeout, debug):
     ctx.timeout = timeout
     ctx.output = output
     ctx.debug = debug
+    ctx.insecure = insecure
 
     _LOGGER.debug("Using settings: %s", ctx)
 

--- a/homeassistant_cli/config.py
+++ b/homeassistant_cli/config.py
@@ -14,6 +14,7 @@ class Configuration(object):
         self.server = DEFAULT_SERVER
         self.output = DEFAULT_OUTPUT
         self.token = None
+        self.insecure = False
 
     def log(self, msg, *args):
         """Log a message to stdout."""
@@ -31,8 +32,9 @@ class Configuration(object):
         view = {
             "server": self.server,
             "access-token": 'yes' if self.token is not None else 'no',
+            "insecure": self.insecure,
             "output":  self.output,
-            "verbose": self.verbose
+            "verbose": self.verbose,
         }
 
         return "<Configuration({})".format(view)

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -57,11 +57,11 @@ def restapi(ctx: Configuration, method: str, path: str,
         if method == METH_GET:
             return requests.get(
                 url, params=data_str, timeout=ctx.timeout,
-                headers=headers)
+                headers=headers, verify=not ctx.insecure)
 
         return requests.request(
             method, url, data=data_str, timeout=ctx.timeout,
-            headers=headers)
+            headers=headers, verify=not ctx.insecure)
 
     except requests.exceptions.ConnectionError:
         raise HomeAssistantCliError("Error connecting to {}".format(url))


### PR DESCRIPTION
Why:

 * users setting up hass or hass.io might enable signed certificates
   and when they do hass-cli would fail to connect due to default
   SSL validation.

This change addreses the need by:

 * introduce --insecure flag which will disable SSL verificaiton
   (but not hostname verfication) to allow use of self-signed certs.

Fixes #8