### PR TITLE
print configuration settings to debug log

### DIFF
--- a/.github/move.yml
+++ b/.github/move.yml
@@ -1,0 +1,19 @@
+# Configuration for move-issues - https://github.com/dessant/move-issues
+
+# Delete the command comment when it contains no other content
+deleteCommand: true
+
+# Close the source issue after moving
+closeSourceIssue: true
+
+# Lock the source issue after moving
+lockSourceIssue: false
+
+# Mention issue and comment authors
+mentionAuthors: true
+
+# Preserve mentions in the issue content
+keepContentMentions: false
+
+# Move labels that also exist on the target repository
+moveLabels: true

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,4 @@
+template: |
+  ## What's Changed
+
+  $CHANGES

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,9 @@ ctags.tmp
 virtualization/vagrant/setup_done
 virtualization/vagrant/.vagrant
 virtualization/vagrant/config
+
+# pytest 
+.pytest_cache
+
+# share/man ignore
+share

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+python:
+  enabled: true

--- a/README.rst
+++ b/README.rst
@@ -113,31 +113,32 @@ help
 
 .. code:: bash
 
-  Usage: hass-cli [OPTIONS] COMMAND [ARGS]...
+    Usage: hass-cli [OPTIONS] COMMAND [ARGS]...
 
-    A command line interface for Home Assistant.
+      A command line interface for Home Assistant.
 
-  Options:
-    --version                 Show the version and exit.
-    -s, --server TEXT         The server URL of Home Assistant instance.
-                              [default: http://localhost:8123]
-    --token TEXT              The Bearer token for Home Assistant instance.
-    --timeout INTEGER         Timeout for network operations.
-    -o, --output [json|yaml]  Output format  [default: json]
-    -v, --verbose             Enables verbose mode.
-    --help                    Show this message and exit.
+    Options:
+      --version                 Show the version and exit.
+      -s, --server TEXT         The server URL of Home Assistant instance.
+                                [default: http://localhost:8123]
+      --token TEXT              The Bearer token for Home Assistant instance.
+      --timeout INTEGER         Timeout for network operations.
+      -o, --output [json|yaml]  Output format  [default: json]
+      -v, --verbose             Enables verbose mode.
+      --debug                   Enables debug mode.
+      --help                    Show this message and exit.
 
-  Commands:
-    completion  Output shell completion code for the specified shell (bash or...
-    config      Get basic info from Home Assistant using /api/config.
-    delete      Delete entities.
-    discover    Discovery for the local network.
-    edit        Edit entities.
-    get         list info from Home Assistant
-    info        Get basic info from Home Assistant using /api/discovery_info.
-    map         Print the current location on a map.
-    raw         Call the raw API (advanced).
-    toggle      toggle data from Home Assistant
+    Commands:
+      completion  Output shell completion code for the specified shell (bash or...
+      config      Get configuration from Home Assistant.
+      delete      Delete entities.
+      discover    Discovery for the local network.
+      edit        Edit entities.
+      get         List info from Home Assistant.
+      info        Get basic info from Home Assistant.
+      map         Print the current location on a map.
+      raw         Call the raw API (advanced).
+      toggle      Toggle data from Home Assistant.
 
 
 Clone the git repository and 

--- a/README.rst
+++ b/README.rst
@@ -128,12 +128,17 @@ help
     --help                    Show this message and exit.
 
   Commands:
-    discover  Discovery for the local network.
-    edit      list info from Home Assistant
-    get       list info from Home Assistant
-    info      Get basic info from Home Assistant using /api/discovery_info.
-    raw       call raw api (advanced)
-    toggle    toggle data from Home Assistant
+    completion  Output shell completion code for the specified shell (bash or...
+    config      Get basic info from Home Assistant using /api/config.
+    delete      Delete entities.
+    discover    Discovery for the local network.
+    edit        Edit entities.
+    get         list info from Home Assistant
+    info        Get basic info from Home Assistant using /api/discovery_info.
+    map         Print the current location on a map.
+    raw         Call the raw API (advanced).
+    toggle      toggle data from Home Assistant
+
 
 Clone the git repository and 
 

--- a/homeassistant_cli/autocompletion.py
+++ b/homeassistant_cli/autocompletion.py
@@ -1,8 +1,8 @@
 """Details for the auto-completion."""
 import os
 
-from homeassistant_cli.helper import (
-    debug_requests_on, format_output, req, req_raw)
+from homeassistant_cli import const
+from homeassistant_cli.helper import req
 from requests.exceptions import HTTPError
 
 
@@ -16,7 +16,7 @@ def _init_ctx(ctx):
     if not hasattr(ctx, 'token'):
         ctx.token = os.environ.get('HASS_TOKEN')
 
-    if not hasattr(ctx, "timeout"):
+    if not hasattr(ctx, 'timeout'):
         ctx.timeout = os.environ.get('HASS_TIMEOUT', const.DEFAULT_TIMEOUT)
 
 
@@ -24,7 +24,7 @@ def entities(ctx, args, incomplete):
     """Entities."""
     _init_ctx(ctx)
     try:
-        response = req(ctx, "get", "states")
+        response = req(ctx, 'get', 'states')
     except HTTPError:
         response = None
 
@@ -32,7 +32,7 @@ def entities(ctx, args, incomplete):
 
     if response is not None:
         for entity in response:
-            entities.append((entity["entity_id"], ''))
+            entities.append((entity['entity_id'], ''))
 
         entities.sort()
 
@@ -45,15 +45,15 @@ def events(ctx, args, incomplete):
     """Events."""
     _init_ctx(ctx)
     try:
-        response = req(ctx, "get", "events")
+        response = req(ctx, 'get', 'events')
     except HTTPError:
         response = None
 
     entities = []
 
-    if x is not None:
+    if response is not None:
         for entity in response:
-            entities.append((entity["event"], ''))
+            entities.append((entity['event'], ''))
 
         entities.sort()
 

--- a/homeassistant_cli/autocompletion.py
+++ b/homeassistant_cli/autocompletion.py
@@ -28,17 +28,17 @@ def entities(ctx, args, incomplete):
     except HTTPError:
         response = None
 
-    entities = []
+    completions = []
 
     if response is not None:
         for entity in response:
-            entities.append((entity['entity_id'], ''))
+            completions.append((entity['entity_id'], ''))
 
-        entities.sort()
+        completions.sort()
 
         return [c for c in entities if incomplete in c[0]]
     else:
-        return entities
+        return completions
 
 
 def events(ctx, args, incomplete):
@@ -49,14 +49,14 @@ def events(ctx, args, incomplete):
     except HTTPError:
         response = None
 
-    entities = []
+    completions = []
 
     if response is not None:
         for entity in response:
-            entities.append((entity['event'], ''))
+            completions.append((entity['event'], ''))
 
-        entities.sort()
+        completions.sort()
 
         return [c for c in entities if incomplete in c[0]]
     else:
-        return entities
+        return completions

--- a/homeassistant_cli/cli.py
+++ b/homeassistant_cli/cli.py
@@ -112,6 +112,6 @@ def cli(ctx, verbose, server, token, output, timeout, debug):
     ctx.debug = debug
 
     _LOGGER.debug("Using settings: %s", ctx)
-        
+
     if debug:
         debug_requests_on()

--- a/homeassistant_cli/cli.py
+++ b/homeassistant_cli/cli.py
@@ -125,6 +125,7 @@ def _default_token():
                     ' Be careful!'))
 @click.option('--debug', is_flag=True, default=False,
               help='Enables debug mode.')
+@click.version_option()
 @pass_context
 def cli(ctx, verbose, server, token, output, timeout, debug, insecure):
     """Command line interface for Home Assistant."""

--- a/homeassistant_cli/cli.py
+++ b/homeassistant_cli/cli.py
@@ -111,5 +111,7 @@ def cli(ctx, verbose, server, token, output, timeout, debug):
     ctx.output = output
     ctx.debug = debug
 
+    _LOGGER.debug("Using settings: %s", ctx)
+        
     if debug:
         debug_requests_on()

--- a/homeassistant_cli/cli.py
+++ b/homeassistant_cli/cli.py
@@ -19,13 +19,13 @@ class HomeAssistantCli(click.MultiCommand):
 
     def list_commands(self, ctx):
         """List all command available as plugin."""
-        rv = []
+        commands = []
         for filename in os.listdir(cmd_folder):
             if filename.endswith('.py') and not filename.startswith('__'):
-                rv.append(filename[:-3])
-        rv.sort()
+                commands.append(filename[:-3])
+        commands.sort()
 
-        return rv
+        return commands
 
     def get_command(self, ctx, name):
         """Import the commands of the plugins."""

--- a/homeassistant_cli/cli.py
+++ b/homeassistant_cli/cli.py
@@ -99,10 +99,15 @@ class HomeAssistantCli(click.MultiCommand):
               default='json', show_default=True)
 @click.option('-v', '--verbose', is_flag=True,
               help='Enables verbose mode.')
+@click.option('--insecure', is_flag=True, default=False,
+              help=('Ignore SSL Certificates.'
+                    ' Allow to connect to servers with'
+                    ' self-signed certificates.'
+                    ' Be careful!'))
 @click.option('--debug', is_flag=True, default=False,
               help='Enables debug mode.')
 @pass_context
-def cli(ctx, verbose, server, token, output, timeout, debug):
+def cli(ctx, verbose, server, token, output, timeout, debug, insecure):
     """Command line interface for Home Assistant."""
     ctx.verbose = verbose
     ctx.server = server
@@ -110,6 +115,7 @@ def cli(ctx, verbose, server, token, output, timeout, debug):
     ctx.timeout = timeout
     ctx.output = output
     ctx.debug = debug
+    ctx.insecure = insecure
 
     _LOGGER.debug("Using settings: %s", ctx)
 

--- a/homeassistant_cli/config.py
+++ b/homeassistant_cli/config.py
@@ -28,11 +28,11 @@ class Configuration(object):
 
     def __repr__(self) -> str:
         """Return the representation of the Configuration."""
-        
         view = {
-            "server" : self.server,
+            "server": self.server,
             "access-token": 'yes' if self.token is not None else 'no',
-            "output" :  self.output,
-            "verbose" : self.verbose
+            "output":  self.output,
+            "verbose": self.verbose
         }
+
         return "<Configuration({})".format(view)

--- a/homeassistant_cli/config.py
+++ b/homeassistant_cli/config.py
@@ -28,7 +28,11 @@ class Configuration(object):
 
     def __repr__(self) -> str:
         """Return the representation of the Configuration."""
-        return "<Configuration({}, access-token: {}, \
-                output: {}, verbose: {})>".format(
-            self.server, 'yes' if self.token is not None else 'no',
-            self.output, self.verbose)
+        
+        view = {
+            "server" : self.server,
+            "access-token": 'yes' if self.token is not None else 'no',
+            "output" :  self.output,
+            "verbose" : self.verbose
+        }
+        return "<Configuration({})".format(view)

--- a/homeassistant_cli/config.py
+++ b/homeassistant_cli/config.py
@@ -14,6 +14,7 @@ class Configuration(object):
         self.server = DEFAULT_SERVER
         self.output = DEFAULT_OUTPUT
         self.token = None
+        self.insecure = False
 
     def log(self, msg, *args):
         """Log a message to stdout."""
@@ -31,8 +32,9 @@ class Configuration(object):
         view = {
             "server": self.server,
             "access-token": 'yes' if self.token is not None else 'no',
+            "insecure": self.insecure,
             "output":  self.output,
-            "verbose": self.verbose
+            "verbose": self.verbose,
         }
 
         return "<Configuration({})".format(view)

--- a/homeassistant_cli/config.py
+++ b/homeassistant_cli/config.py
@@ -10,10 +10,10 @@ class Configuration(object):
 
     def __init__(self):
         """Initialize the configuration."""
-
         self.verbose = False
         self.server = DEFAULT_SERVER
         self.output = DEFAULT_OUTPUT
+        self.token = None
 
     def log(self, msg, *args):
         """Log a message to stdout."""
@@ -25,3 +25,10 @@ class Configuration(object):
         """Log a message only if verbose is enabled."""
         if self.verbose:
             self.log(msg, *args)
+
+    def __repr__(self) -> str:
+        """Return the representation of the Configuration."""
+        return "<Configuration({}, access-token: {}, \
+                output: {}, verbose: {})>".format(
+            self.server, 'yes' if self.token is not None else 'no',
+            self.output, self.verbose)

--- a/homeassistant_cli/const.py
+++ b/homeassistant_cli/const.py
@@ -1,6 +1,7 @@
 """Constants used by Home Assistant CLI (hass-cli)."""
 PACKAGE_NAME = 'homeassistant_cli'
-__version__ = '0.0.3-dev'
+
+__version__ = '0.1.0-dev'
 
 REQUIRED_PYTHON_VER = (3, 5, 3)
 

--- a/homeassistant_cli/const.py
+++ b/homeassistant_cli/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant CLI (hass-cli)."""
 PACKAGE_NAME = 'homeassistant_cli'
 
-__version__ = '0.2.0-dev'
+__version__ = '0.2.0.dev'
 
 REQUIRED_PYTHON_VER = (3, 5, 3)
 

--- a/homeassistant_cli/const.py
+++ b/homeassistant_cli/const.py
@@ -6,5 +6,6 @@ __version__ = '0.2.0.dev'
 REQUIRED_PYTHON_VER = (3, 5, 3)
 
 DEFAULT_SERVER = 'http://localhost:8123'
+DEFAULT_HASSIO_SERVER = 'http://hassio/homeassistant'
 DEFAULT_TIMEOUT = 5
 DEFAULT_OUTPUT = 'json'  # TODO: Have default be human table relevant output

--- a/homeassistant_cli/const.py
+++ b/homeassistant_cli/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant CLI (hass-cli)."""
 PACKAGE_NAME = 'homeassistant_cli'
 
-__version__ = '0.1.0-dev'
+__version__ = '0.2.0-dev'
 
 REQUIRED_PYTHON_VER = (3, 5, 3)
 

--- a/homeassistant_cli/const.py
+++ b/homeassistant_cli/const.py
@@ -1,9 +1,9 @@
 """Constants used by Home Assistant CLI (hass-cli)."""
 PACKAGE_NAME = 'homeassistant_cli'
-__version__ = '0.0.1'
+__version__ = '0.0.3-dev'
 
 REQUIRED_PYTHON_VER = (3, 5, 3)
 
-DEFAULT_SERVER = "http://localhost:8123"
+DEFAULT_SERVER = 'http://localhost:8123'
 DEFAULT_TIMEOUT = 5
-DEFAULT_OUTPUT = "json" ## todo: have default be human table relevant output
+DEFAULT_OUTPUT = 'json'  # TODO: Have default be human table relevant output

--- a/homeassistant_cli/exceptions.py
+++ b/homeassistant_cli/exceptions.py
@@ -1,0 +1,7 @@
+"""The exceptions used by Home Assistant CLI."""
+
+
+class HomeAssistantCliError(Exception):
+    """General Home Assistant CLI exception occurred."""
+
+    pass

--- a/homeassistant_cli/helper.py
+++ b/homeassistant_cli/helper.py
@@ -13,18 +13,18 @@ import yaml
 
 def raw_format_output(output, data):
     """Format the raw output."""
-    if output == "json":
+    if output == 'json':
         try:
             return json.dumps(data, indent=2, sort_keys=False)
         except ValueError:
             return input
-    elif output == "yaml":
+    elif output == 'yaml':
         try:
             return yaml.safe_dump(data, default_flow_style=False)
         except ValueError:
             return input
     # todo fix this so gets a jsonpath list to transpose data
-    elif output == "human":
+    elif output == 'human':
         return table(data)
     else:
         raise ValueError(
@@ -84,7 +84,7 @@ def debug_requests_on():
 
     logging.basicConfig()
     logging.getLogger().setLevel(logging.DEBUG)
-    requests_log = logging.getLogger("requests.packages.urllib3")
+    requests_log = logging.getLogger('requests.packages.urllib3')
     requests_log.setLevel(logging.DEBUG)
     requests_log.propagate = True
 
@@ -96,7 +96,7 @@ def debug_requests_off():
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.WARNING)
     root_logger.handlers = []
-    requests_log = logging.getLogger("requests.packages.urllib3")
+    requests_log = logging.getLogger('requests.packages.urllib3')
     requests_log.setLevel(logging.WARNING)
     requests_log.propagate = False
 

--- a/homeassistant_cli/helper.py
+++ b/homeassistant_cli/helper.py
@@ -7,7 +7,6 @@ import logging
 import click
 import requests
 import tabulate
-from tabulate import tabulate
 import yaml
 
 
@@ -90,7 +89,10 @@ def debug_requests_on():
 
 
 def debug_requests_off():
-    """Switch off logging of the requests module, might be some side-effects."""
+    """Switch off logging of the requests module.
+
+    Might have some side-effects.
+    """
     HTTPConnection.debuglevel = 0
 
     root_logger = logging.getLogger()
@@ -103,7 +105,10 @@ def debug_requests_off():
 
 @contextlib.contextmanager
 def debug_requests():
-    """Use with 'with'!"""
+    """Yieldable way to turn on debugs for requests.
+
+    with debug_requests(): <do things>
+    """
     debug_requests_on()
     yield
     debug_requests_off()

--- a/homeassistant_cli/helper.py
+++ b/homeassistant_cli/helper.py
@@ -74,8 +74,8 @@ def req(ctx, method, endpoint, *args):
 
     if resp:
         return resp.json()
-    else:
-        click.echo("Got empty response from server")
+
+    click.echo("Got empty response from server")
 
 
 def debug_requests_on():

--- a/homeassistant_cli/plugins/config.py
+++ b/homeassistant_cli/plugins/config.py
@@ -1,0 +1,11 @@
+"""Config plugin for Home Assistant CLI (hass-cli)."""
+import click
+from homeassistant_cli.cli import pass_context
+from homeassistant_cli.helper import format_output, req
+
+
+@click.command('config')
+@pass_context
+def cli(ctx):
+    """Get basic info from Home Assistant using /api/config."""
+    click.echo(format_output(ctx, req(ctx, 'get', 'config')))

--- a/homeassistant_cli/plugins/config.py
+++ b/homeassistant_cli/plugins/config.py
@@ -1,4 +1,4 @@
-"""Config plugin for Home Assistant CLI (hass-cli)."""
+"""Configuration plugin for Home Assistant CLI (hass-cli)."""
 import click
 from homeassistant_cli.cli import pass_context
 from homeassistant_cli.helper import format_output, req
@@ -7,5 +7,5 @@ from homeassistant_cli.helper import format_output, req
 @click.command('config')
 @pass_context
 def cli(ctx):
-    """Get basic info from Home Assistant using /api/config."""
+    """Get configuration from Home Assistant."""
     click.echo(format_output(ctx, req(ctx, 'get', 'config')))

--- a/homeassistant_cli/plugins/delete.py
+++ b/homeassistant_cli/plugins/delete.py
@@ -2,12 +2,14 @@
 import click
 import homeassistant_cli.autocompletion as autocompletion
 from homeassistant_cli.cli import pass_context
+from homeassistant_cli.helper import req_raw
 
 
 @click.group('delete')
 @pass_context
 def cli(ctx):
     """Delete entities."""
+
 
 @cli.command()
 @click.argument('entity', required='true',

--- a/homeassistant_cli/plugins/discover.py
+++ b/homeassistant_cli/plugins/discover.py
@@ -5,7 +5,8 @@ from homeassistant_cli.helper import format_output
 
 
 @click.command('discover')
-@click.option('--raw', is_flag=True, help="Include raw data found during scan.")
+@click.option('--raw', is_flag=True,
+              help="Include raw data found during scan.")
 @pass_context
 def cli(ctx, raw):
     """Discovery for the local network."""

--- a/homeassistant_cli/plugins/edit.py
+++ b/homeassistant_cli/plugins/edit.py
@@ -17,7 +17,8 @@ def cli(ctx):
 
 
 @cli.command()
-@click.argument('entity', required=True, autocompletion=autocompletion.entities)
+@click.argument('entity', required=True,
+                autocompletion=autocompletion.entities)
 @click.argument('newstate', required=False)
 @click.option('--attributes',
               help="Comma separated key/value pairs to use as attributes")

--- a/homeassistant_cli/plugins/edit.py
+++ b/homeassistant_cli/plugins/edit.py
@@ -1,13 +1,12 @@
 """Edit plugin for Home Assistant CLI (hass-cli)."""
 import json as json_
 import shlex
-import urllib.parse
 
 import click
 import homeassistant_cli.autocompletion as autocompletion
 from homeassistant_cli.cli import pass_context
 from homeassistant_cli.helper import (
-    format_output, raw_format_output, req, req_raw)
+    raw_format_output, req_raw)
 import yaml
 
 
@@ -54,22 +53,22 @@ def state(ctx, entity, newstate, attributes, merge, json):
             lexer.whitespace = ','
             attributes_dict = dict(pair.split('=', 1) for pair in lexer)
 
-            newattr = wanted_state.get("attributes", {})
+            newattr = wanted_state.get('attributes', {})
             newattr.update(attributes_dict)
-            wanted_state["attributes"] = newattr
+            wanted_state['attributes'] = newattr
 
         if newstate:
-            wanted_state["state"] = newstate
+            wanted_state['state'] = newstate
         else:
             if not existing_state:
                 raise ValueError("No new or existing state provided.")
-            wanted_state["state"] = existing_state["state"]
+            wanted_state['state'] = existing_state['state']
 
         print("wanted:", str(wanted_state))
-        newjson = raw_format_output("json", wanted_state)
+        newjson = raw_format_output('json', wanted_state)
 
         response = req_raw(ctx, 'post', 'states/{}'.format(entity), newjson)
-    else: ## no data passed, just use editor
+    else:
         existing = req_raw(ctx, 'get', 'states/{}'.format(entity)).json()
 
         existing = raw_format_output(ctx.output, existing)
@@ -107,4 +106,4 @@ def event(ctx, event, json):
             response = req_raw(ctx, 'post', 'events/{}'.format(event), new)
             response.raise_for_status()
         else:
-            print("No edits/changes.")
+            click.echo("No edits/changes.")

--- a/homeassistant_cli/plugins/get.py
+++ b/homeassistant_cli/plugins/get.py
@@ -2,15 +2,13 @@
 import click
 import homeassistant_cli.autocompletion as autocompletion
 from homeassistant_cli.cli import pass_context
-import homeassistant_cli.const as const
-from homeassistant_cli.helper import (
-    debug_requests_on, format_output, req, req_raw)
+from homeassistant_cli.helper import format_output, req, req_raw
 
 
 @click.group('get')
 @pass_context
 def cli(ctx):
-    """list info from Home Assistant"""
+    """List info from Home Assistant."""
 
 
 @cli.command()

--- a/homeassistant_cli/plugins/get.py
+++ b/homeassistant_cli/plugins/get.py
@@ -19,8 +19,8 @@ def state(ctx, entity):
     """Get/read state from Home Assistant."""
     if not entity:
         response = req_raw(ctx, 'get', 'states')
-        response.raise_for_status
-        click.echo(format_output(ctx, r.json()))
+        response.raise_for_status()
+        click.echo(format_output(ctx, response.json()))
     else:
         click.echo(format_output(ctx, req(
             ctx, 'get', 'states/{}'.format(entity))))
@@ -39,9 +39,11 @@ def service(ctx):
     """List services from Home Assistant."""
     click.echo(format_output(ctx, req(ctx, 'get', 'services')))
 
+# todo: time from/to as human delta dates
+
 
 @cli.command()
-@click.argument('entities', nargs=-1) ## do time from/to as human delta dates
+@click.argument('entities', nargs=-1)
 @pass_context
 def history(ctx, entities):
     """List history from Home Assistant."""

--- a/homeassistant_cli/plugins/info.py
+++ b/homeassistant_cli/plugins/info.py
@@ -7,5 +7,5 @@ from homeassistant_cli.helper import format_output, req
 @click.command('info')
 @pass_context
 def cli(ctx):
-    """Get basic info from Home Assistant using /api/discovery_info."""
+    """Get basic info from Home Assistant."""
     click.echo(format_output(ctx, req(ctx, 'get', 'discovery_info')))

--- a/homeassistant_cli/plugins/info.py
+++ b/homeassistant_cli/plugins/info.py
@@ -1,4 +1,4 @@
-"""Location plugin for Home Assistant CLI (hass-cli)."""
+"""Info plugin for Home Assistant CLI (hass-cli)."""
 import click
 from homeassistant_cli.cli import pass_context
 from homeassistant_cli.helper import format_output, req

--- a/homeassistant_cli/plugins/map.py
+++ b/homeassistant_cli/plugins/map.py
@@ -1,0 +1,21 @@
+"""Map plugin for Home Assistant CLI (hass-cli)."""
+import webbrowser
+
+import click
+
+from homeassistant_cli.cli import pass_context
+from homeassistant_cli.helper import req
+
+OSM_URL = 'https://www.openstreetmap.org'
+ZOOM = 17
+
+
+@click.command('map')
+@pass_context
+def cli(ctx):
+    """Print the current location on a map."""
+    response = req(ctx, 'get', 'config')
+
+    url = '{0}/?mlat={2}&mlon={3}#map={1}/{2}/{3}'.format(
+        OSM_URL, ZOOM, response.get('latitude'), response.get('longitude'))
+    webbrowser.open_new_tab(url)

--- a/homeassistant_cli/plugins/raw.py
+++ b/homeassistant_cli/plugins/raw.py
@@ -11,7 +11,7 @@ def cli(ctx):
 
 
 @cli.command()
-@click.argument("method")
+@click.argument('method')
 @pass_context
 def get(ctx, method):
     """Do a GET request against api/<method>."""
@@ -19,7 +19,7 @@ def get(ctx, method):
 
 
 @cli.command()
-@click.argument("method")
+@click.argument('method')
 @click.option('--json')
 @pass_context
 def post(ctx, method, json):

--- a/homeassistant_cli/plugins/raw.py
+++ b/homeassistant_cli/plugins/raw.py
@@ -1,7 +1,7 @@
 """Raw plugin for Home Assistant CLI (hass-cli)."""
 import click
 from homeassistant_cli.cli import pass_context
-from homeassistant_cli.helper import format_output, req, req_raw
+from homeassistant_cli.helper import format_output, req
 
 
 @click.group('raw')

--- a/homeassistant_cli/plugins/toggle.py
+++ b/homeassistant_cli/plugins/toggle.py
@@ -4,12 +4,13 @@ import json
 import click
 import homeassistant_cli.autocompletion as autocompletion
 from homeassistant_cli.cli import pass_context
+from homeassistant_cli.helper import format_output, req_raw
 
 
 @click.group('toggle')
 @pass_context
 def cli(ctx):
-    """toggle data from Home Assistant"""
+    """Toggle data from Home Assistant."""
 
 
 @cli.command()
@@ -17,7 +18,7 @@ def cli(ctx):
                 autocompletion=autocompletion.entities)
 @pass_context
 def state(ctx, entities):
-    """toggle state from Home Assistant"""
+    """Toggle state from Home Assistant."""
     for entity in entities:
         data = {'entity_id': entity}
         click.echo("Toggling {}".format(entity))

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -1,0 +1,163 @@
+"""
+Basic api to access remote instance of Home Assistant.
+
+If a connection error occurs while communicating with the API a
+HomeAssistantCliError will be raised.
+
+"""
+from datetime import datetime
+import enum
+import json
+import logging
+import urllib.parse
+
+from typing import Optional, Dict, Any
+
+from aiohttp.hdrs import METH_GET, METH_POST, METH_DELETE, CONTENT_TYPE
+import requests
+
+from homeassistant_cli.config import Configuration
+from homeassistant_cli.exceptions import HomeAssistantCliError
+
+from homeassistant.const import (
+    URL_API, URL_API_DISCOVERY_INFO, URL_API_EVENTS, CONTENT_TYPE_JSON,
+    URL_API_EVENTS_EVENT, URL_API_STATES_ENTITY)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class APIStatus(enum.Enum):
+    """Representation of an API status."""
+
+    OK = "ok"
+    INVALID_PASSWORD = "invalid_password"
+    CANNOT_CONNECT = "cannot_connect"
+    UNKNOWN = "unknown"
+
+    def __str__(self) -> str:
+        """Return the state."""
+        return self.value  # type: ignore
+
+
+def restapi(ctx: Configuration, method: str, path: str,
+            data: Dict = None) -> requests.Response:
+    """Make a call to the Home Assistant REST API."""
+    if data is None:
+        data_str = None
+    else:
+        data_str = json.dumps(data, cls=JSONEncoder)
+
+    headers = {CONTENT_TYPE: CONTENT_TYPE_JSON}
+    if ctx.token is not None:
+        headers['Authorization'] = 'Bearer: {}'.format(ctx.token)
+
+    url = urllib.parse.urljoin(ctx.server, path)
+
+    try:
+        if method == METH_GET:
+            return requests.get(
+                url, params=data_str, timeout=ctx.timeout,
+                headers=headers)
+
+        return requests.request(
+            method, url, data=data_str, timeout=ctx.timeout,
+            headers=headers)
+
+    except requests.exceptions.ConnectionError:
+        raise HomeAssistantCliError("Error connecting to {}".format(url))
+
+    except requests.exceptions.Timeout:
+        error = "Timeout when talking to {}".format(url)
+        _LOGGER.exception(error)
+        raise HomeAssistantCliError(error)
+
+
+class JSONEncoder(json.JSONEncoder):
+    """JSONEncoder that supports Home Assistant objects."""
+
+    # pylint: disable=method-hidden
+    def default(self, o: Any) -> Any:
+        """Convert Home Assistant objects.
+
+        Hand other objects to the original method.
+        """
+        if isinstance(o, datetime):
+            return o.isoformat()
+        if isinstance(o, set):
+            return list(o)
+        if hasattr(o, 'as_dict'):
+            return o.as_dict()
+
+        return json.JSONEncoder.default(self, o)
+
+
+def validate_api(ctx: Configuration) -> APIStatus:
+    """Make a call to validate API."""
+    try:
+        req = restapi(ctx, METH_GET, URL_API)
+
+        if req.status_code == 200:
+            return APIStatus.OK
+
+        if req.status_code == 401:
+            return APIStatus.INVALID_PASSWORD
+
+        return APIStatus.UNKNOWN
+
+    except HomeAssistantCliError:
+        return APIStatus.CANNOT_CONNECT
+
+
+def get_info(ctx: Configuration) -> Optional[Dict]:
+    """Get basic info about the Homeassistant instance."""
+    try:
+        req = restapi(ctx, METH_GET, URL_API_DISCOVERY_INFO)
+
+        return req.json() if req.status_code == 200 else {}  # type: ignore
+
+    except (HomeAssistantCliError, ValueError):
+        raise HomeAssistantCliError("Unexpected error retriving info")
+        # ValueError if req.json() can't parse the json
+
+
+def remove_state(ctx: Configuration, entity_id: str) -> Optional[Dict]:
+    """Call API to remove state for entity_id."""
+    try:
+        req = restapi(ctx, METH_DELETE,
+                      URL_API_STATES_ENTITY.format(entity_id))
+
+        if req.status_code in (200, 404):
+            return True
+    except HomeAssistantCliError:
+        raise HomeAssistantCliError("Unexpected error removing state")
+
+    raise HomeAssistantCliError("Error removing state: %d - %s",
+                                req.status_code, req.text)
+
+
+def get_event_listeners(ctx: Configuration) -> Dict:
+    """List of events that is being listened for."""
+    try:
+        req = restapi(ctx, METH_GET, URL_API_EVENTS)
+
+        return req.json() if req.status_code == 200 else {}  # type: ignore
+
+    except (HomeAssistantCliError, ValueError):
+        # ValueError if req.json() can't parse the json
+        _LOGGER.exception("Unexpected result retrieving event listeners")
+
+        return {}
+
+
+def fire_event(ctx: Configuration, event_type: str, data: Dict = None) -> None:
+    """Fire an event at remote API."""
+    try:
+        req = restapi(ctx, METH_POST,
+                      URL_API_EVENTS_EVENT.format(event_type), data)
+
+        if req.status_code != 200:
+            _LOGGER.error("Error firing event: %d - %s",
+                          req.status_code, req.text)
+
+    except HomeAssistantCliError:
+        _LOGGER.exception("Error firing event")

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -57,11 +57,11 @@ def restapi(ctx: Configuration, method: str, path: str,
         if method == METH_GET:
             return requests.get(
                 url, params=data_str, timeout=ctx.timeout,
-                headers=headers)
+                headers=headers, verify=not ctx.insecure)
 
         return requests.request(
             method, url, data=data_str, timeout=ctx.timeout,
-            headers=headers)
+            headers=headers, verify=not ctx.insecure)
 
     except requests.exceptions.ConnectionError:
         raise HomeAssistantCliError("Error connecting to {}".format(url))

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ PROJECT_COPYRIGHT = ' 2018-{}, {}'.format(dt.now().year, PROJECT_AUTHOR)
 PROJECT_URL = 'https://github.com/home-assistant/home-assistant-cli/'
 PROJECT_EMAIL = 'hello@home-assistant.io'
 
-PROJECT_GITHUB_USERNAME = 'home-assistant' 
+PROJECT_GITHUB_USERNAME = 'home-assistant'
 PROJECT_GITHUB_REPOSITORY = 'home-assistant-cli'
 
 PYPI_URL = 'https://pypi.python.org/pypi/{}'.format(PROJECT_PACKAGE_NAME)
@@ -22,7 +22,8 @@ GITHUB_PATH = '{}/{}'.format(
     PROJECT_GITHUB_USERNAME, PROJECT_GITHUB_REPOSITORY)
 GITHUB_URL = 'https://github.com/{}'.format(GITHUB_PATH)
 
-DOWNLOAD_URL = '{}/archive/{}.zip'.format(GITHUB_URL, hass_cli_const.__version__)
+DOWNLOAD_URL = '{}/archive/{}.zip'.format(GITHUB_URL,
+                                          hass_cli_const.__version__)
 PROJECT_URLS = {
     'Bug Reports': '{}/issues'.format(GITHUB_URL),
     'Dev Docs': 'https://developers.home-assistant.io/',
@@ -34,13 +35,27 @@ PACKAGES = find_packages(exclude=['tests', 'tests.*'])
 
 REQUIRES = [
     'click',
+    'click-log',
     'homeassistant',
     'netdisco',
-    'tabulate',
-    'jsonpath-rw'
+    'tabulate'
+]
+
+TESTS_REQUIRE = [
+    'requests_mock==1.5.2',
+    'flake8-docstrings==1.3.0',
+    'flake8==3.6.0',
+    'pytest==4.0.0',
+    'pylint==2.1.1',
 ]
 
 MIN_PY_VERSION = '.'.join(map(str, hass_cli_const.REQUIRED_PYTHON_VER))
+
+# allow you to run pip3 install .[test] to get
+# test dependencies included.
+EXTRAS_REQUIRE = {
+    'test': TESTS_REQUIRE
+}
 
 setup(
     name=PROJECT_PACKAGE_NAME,
@@ -54,11 +69,13 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=REQUIRES,
+    tests_require=TESTS_REQUIRE,
+    extras_require=EXTRAS_REQUIRE,
     python_requires='>={}'.format(MIN_PY_VERSION),
     test_suite='tests',
     entry_points={
         'console_scripts': [
-            'hass-cli = homeassistant_cli.cli:cli'
+            'hass-cli = homeassistant_cli.cli:run'
         ]
     },
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Init file for Home Assistant CLI tests."""

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,0 +1,49 @@
+"""Tests file for Home Assistant CLI (hass-cli)."""
+import os
+
+import homeassistant_cli.cli as cli
+from homeassistant_cli.config import Configuration
+from unittest import mock
+import pytest
+
+HASSIO_SERVER_FALLBACK = "http://hassio/homeassistant"
+HASS_SERVER = "http://localhost:8123"
+
+
+@pytest.mark.parametrize("description,env,expected_server,expected_token", [
+   ("No env set, all should be defaults",
+    {},
+    HASS_SERVER,
+    None),
+   ("If only HASSIO_TOKEN, use default hassio",
+    {'HASSIO_TOKEN': 'supersecret'},
+    HASSIO_SERVER_FALLBACK, "supersecret"),
+   ("Honor HASS_SERVER together with HASSIO_TOKEN",
+    {'HASSIO_TOKEN': 'supersecret',
+     'HASS_SERVER': 'http://localhost:999999'},
+    "http://localhost:999999", "supersecret"),
+   ("HASS_TOKEN should win over HASIO_TOKEN",
+    {'HASSIO_TOKEN': 'supersecret',
+     'HASS_TOKEN': 'I Win!'},
+    HASS_SERVER, 'I Win!'),
+])
+def test_defaults(description, env, expected_server, expected_token):
+
+    mockenv = mock.patch.dict(os.environ,
+                              env)
+
+    try:
+        mockenv.start()
+        ctx = cli.cli.make_context('hass-cli', ['--timeout', '1', 'info'])
+        with ctx:
+            try:
+                cli.cli.invoke(ctx)
+            except Exception:
+                pass
+
+        cfg: Configuration = ctx.obj
+
+        assert cfg.server == expected_server
+        assert cfg.token == expected_token
+    finally:
+        mockenv.stop()

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,0 +1,56 @@
+"""Tests file for Home Assistant CLI (hass-cli)."""
+import json
+import yaml
+
+from click.testing import CliRunner
+import homeassistant_cli.cli as cli
+
+import requests_mock
+
+from requests.exceptions import ConnectionError
+
+VALID_INFO = {"base_url": "http://192.168.1.156:8123",
+              "location_name": "Home",
+              "requires_api_password": "false",
+              "version": "0.82.1"}
+
+
+def ordered(obj):
+    """Sort object recursively. Useful for comparing json/yaml dicts."""
+    if isinstance(obj, dict):
+        return sorted((k, ordered(v)) for k, v in obj.items())
+    if isinstance(obj, list):
+        return sorted(ordered(x) for x in obj)
+    else:
+        return obj
+
+
+def test_info_without_server_running():
+    runner = CliRunner()
+    result = runner.invoke(cli.cli, ['--server',
+                                     'http://donotexist.inf',
+                                     'info'])
+    assert result.exit_code == 1
+    assert isinstance(result.exception, ConnectionError)
+
+
+def test_info_json():
+    with requests_mock.Mocker() as m:
+        m.get('http://localhost:8123/api/discovery_info',
+              json=VALID_INFO, status_code=200)
+
+        runner = CliRunner()
+        result = runner.invoke(cli.cli, ['info'], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert VALID_INFO == json.loads(result.output)
+
+
+def test_info_yaml():
+    with requests_mock.Mocker() as m:
+        m.get('http://localhost:8123/api/discovery_info',
+              json=VALID_INFO, status_code=200)
+
+        runner = CliRunner()
+        result = runner.invoke(cli.cli, ['info'], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert VALID_INFO == yaml.load(result.output)


### PR DESCRIPTION
Now when you use `-l DEBUG` hass-cli print out its configuration/settings,
but with token masked out.