### PR TITLE
Add black for formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 79
+skip-string-normalization = true

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,13 @@ PROJECT_GITHUB_REPOSITORY = 'home-assistant-cli'
 
 PYPI_URL = 'https://pypi.python.org/pypi/{}'.format(PROJECT_PACKAGE_NAME)
 GITHUB_PATH = '{}/{}'.format(
-    PROJECT_GITHUB_USERNAME, PROJECT_GITHUB_REPOSITORY)
+    PROJECT_GITHUB_USERNAME, PROJECT_GITHUB_REPOSITORY
+)
 GITHUB_URL = 'https://github.com/{}'.format(GITHUB_PATH)
 
-DOWNLOAD_URL = '{}/archive/{}.zip'.format(GITHUB_URL,
-                                          hass_cli_const.__version__)
+DOWNLOAD_URL = '{}/archive/{}.zip'.format(
+    GITHUB_URL, hass_cli_const.__version__
+)
 PROJECT_URLS = {
     'Bug Reports': '{}/issues'.format(GITHUB_URL),
     'Dev Docs': 'https://developers.home-assistant.io/',
@@ -33,13 +35,7 @@ PROJECT_URLS = {
 
 PACKAGES = find_packages(exclude=['tests', 'tests.*'])
 
-REQUIRES = [
-    'click',
-    'click-log',
-    'homeassistant',
-    'netdisco',
-    'tabulate'
-]
+REQUIRES = ['click', 'click-log', 'homeassistant', 'netdisco', 'tabulate']
 
 TESTS_REQUIRE = [
     'requests_mock==1.5.2',
@@ -47,15 +43,14 @@ TESTS_REQUIRE = [
     'flake8==3.6.0',
     'pytest==4.0.0',
     'pylint==2.1.1',
+    'black==18.9b0',
 ]
 
 MIN_PY_VERSION = '.'.join(map(str, hass_cli_const.REQUIRED_PYTHON_VER))
 
 # allow you to run pip3 install .[test] to get
 # test dependencies included.
-EXTRAS_REQUIRE = {
-    'test': TESTS_REQUIRE
-}
+EXTRAS_REQUIRE = {'test': TESTS_REQUIRE}
 
 setup(
     name=PROJECT_PACKAGE_NAME,
@@ -73,9 +68,5 @@ setup(
     extras_require=EXTRAS_REQUIRE,
     python_requires='>={}'.format(MIN_PY_VERSION),
     test_suite='tests',
-    entry_points={
-        'console_scripts': [
-            'hass-cli = homeassistant_cli.cli:run'
-        ]
-    },
+    entry_points={'console_scripts': ['hass-cli = homeassistant_cli.cli:run']},
 )


### PR DESCRIPTION
Why:

 * getting really tired of manually formatting python code before commit

This change addreses the need by:

 * add black in test dependencies similar to flake8
 * add pyproject.toml as black only supports that format
 * black was chosen as it seem to be the one of the formatters
   that actually is consistent and most "pythonic"
 * did disable its autoformatting of quotes as otherwise
   it would radically change/break with homeassistant formatting
 * note: you'll need to run black manually or enable in your
   editor like vscode.