### PR TITLE
Add precommit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.0.0
+    hooks:
+    - id: flake8
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.7
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: master  # Use the revision sha / tag you want to point at
+    hooks:
+    -   id: isort


### PR DESCRIPTION
Why:

 * precommits are helpful but hard to remember/configure right

This change addreses the need by:

 * adds .pre-commit-config.yaml which enables isort, flake8 and black
   formatting.
 * To use it see details at https://pre-commit.com
   but for trivial cases its:
   ````
   pip install pre-commit
   pre-commit install
   ```

   after that on commit the precommit linters will be run and if any
   failure or updates done the commit will fail.

   Check the failures and edits done - once happy commit again.