### PR TITLE
Add `service` plugin

### DIFF
--- a/homeassistant_cli/helper.py
+++ b/homeassistant_cli/helper.py
@@ -3,6 +3,7 @@ import contextlib
 from http.client import HTTPConnection
 import json
 import logging
+import shlex
 from typing import Any, Dict, Generator, cast
 
 import click
@@ -10,6 +11,18 @@ from homeassistant_cli.config import Configuration
 import requests
 from requests.models import Response
 import yaml
+
+
+def to_attributes(entry: str) -> Dict[str, str]:
+    """Convert list of key=value pairs to dictionary."""
+    lexer = shlex.shlex(entry, posix=True)
+    lexer.whitespace_split = True
+    lexer.whitespace = ','
+    attributes_dict = {}  # type: Dict[str, str]
+    attributes_dict = dict(
+        pair.split('=', 1) for pair in lexer  # type: ignore
+    )
+    return attributes_dict
 
 
 def raw_format_output(output: str, data: Dict[str, Any]) -> str:

--- a/homeassistant_cli/plugins/service.py
+++ b/homeassistant_cli/plugins/service.py
@@ -1,0 +1,77 @@
+"""Location plugin for Home Assistant CLI (hass-cli)."""
+
+import logging
+import re as reg
+import sys
+from typing import Any, Dict, Pattern, no_type_check  # noqa: F401
+
+import click
+import homeassistant_cli.autocompletion as autocompletion
+from homeassistant_cli.cli import pass_context
+from homeassistant_cli.config import Configuration
+from homeassistant_cli.helper import format_output, to_attributes
+import homeassistant_cli.remote as api
+
+_LOGGING = logging.getLogger(__name__)
+
+
+@click.group('service')
+@pass_context
+def cli(ctx):
+    """Call and work with services."""
+
+
+@cli.command('list')
+@click.argument('servicefilter', default=".*", required=False)
+@pass_context
+def list_cmd(ctx: Configuration, servicefilter):
+    """Get list of services."""
+    services = api.get_services(ctx)
+
+    result = {}  # type: Dict[str,Any]
+    if servicefilter == ".*":
+        result = services
+    else:
+        servicefilterre = reg.compile(servicefilter)  # type: Pattern
+
+        for domain in services:
+            domain_name = domain['domain']  # type: ignore
+            domaindata = {}
+            servicesdict = domain['services']  # type: ignore
+            servicedata = {}
+            for service in servicesdict:
+                if servicefilterre.search(
+                    "{}.{}".format(domain_name, service)
+                ):
+                    servicedata[service] = servicesdict[  # type: ignore
+                        service
+                    ]
+
+                if servicedata:
+                    domaindata["services"] = servicedata
+                    result[domain_name] = domaindata
+
+    _LOGGING.info(format_output(ctx, result))
+
+
+@cli.command('call')
+@no_type_check
+@click.argument(
+    'service', required=True, autocompletion=autocompletion.services
+)
+@click.option(
+    '--arguments', help="Comma separated key/value pairs to use as arguments"
+)
+@pass_context
+def call(ctx: Configuration, service, arguments):
+    """Call a service."""
+    parts = service.split(".")
+    if len(parts) != 2:
+        _LOGGING.error("Service name not following <domain>.<service> format.")
+        sys.exit(1)
+
+    data = to_attributes(arguments)
+
+    _LOGGING.info(
+        format_output(ctx, api.call_service(ctx, parts[0], parts[1], data))
+    )

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -295,7 +295,7 @@ def call_service(
     domain: str,
     service: str,
     service_data: Optional[Dict] = None,
-) -> Optional[Dict[str, Any]]:
+) -> Dict[str, Any]:
     """Call a service."""
     try:
         req = restapi(
@@ -304,10 +304,8 @@ def call_service(
             hass.URL_API_SERVICES_SERVICE.format(domain, service),
             service_data,
         )
-    except HomeAssistantCliError:
-        raise HomeAssistantCliError(
-            "Error calling service: {} - {}".format(req.status_code, req.text)
-        )
+    except HomeAssistantCliError as ex:
+        raise HomeAssistantCliError("Error calling service: {}".format(ex))
 
     if req.status_code != 200:
         raise HomeAssistantCliError(
@@ -315,3 +313,20 @@ def call_service(
         )
 
     return cast(Dict[str, Any], req.json())
+
+
+def get_services(ctx: Configuration,) -> Dict[str, Any]:
+    """Get list of services."""
+    try:
+        req = restapi(ctx, METH_GET, hass.URL_API_SERVICES)
+    except HomeAssistantCliError as ex:
+        raise HomeAssistantCliError(
+            "Unexpected error getting services: {}".format(ex)
+        )
+
+    if req.status_code == 200:
+        return cast(Dict[str, Any], req.json())
+
+    raise HomeAssistantCliError(
+        "Error while getting all services: {}".format(req.text)
+    )

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -19,19 +19,19 @@ DFEAULT_PLUGINS = [
     'raw',
     'template',
     'toggle',
+    'service',
 ]
 DFEAULT_PLUGINS.sort()
 
 
 @pytest.fixture(name="defaultplugins_sorted")
 def defaultplugins_fixture() -> List[str]:
-    """Return the exepcted default list of plugins"""
+    """Return the exepcted default list of plugins."""
     return DFEAULT_PLUGINS
 
 
 def test_commands_match_expected(defaultplugins_sorted) -> None:
     """Test plugin discovery."""
-
     hac = HomeAssistantCli()
 
     ctx = cli.make_context('hass-cli', ['info'])
@@ -40,13 +40,14 @@ def test_commands_match_expected(defaultplugins_sorted) -> None:
 
     cmds.sort()
 
-    assert cmds == defaultplugins_sorted
+    diff = set(cmds).difference(set(defaultplugins_sorted))
+
+    assert not diff
 
 
 @pytest.mark.parametrize("plugin", DFEAULT_PLUGINS)
 def test_commands_loads(plugin) -> None:
     """Test plugin discovery."""
-
     hac = HomeAssistantCli()
 
     ctx = cli.make_context('hass-cli', ['info'])

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,120 @@
+"""Tests file for Home Assistant CLI (hass-cli)."""
+import json
+
+from click.testing import CliRunner
+import homeassistant_cli.autocompletion as autocompletion
+import homeassistant_cli.cli as cli
+from homeassistant_cli.config import Configuration
+import requests_mock
+
+VALID_INFO = """[
+    {
+        "domain": "homeassistant",
+        "services": {
+            "check_config": {
+                "description": "Check the Home Assistant configuration files\
+                 for errors. Errors will be displayed in the\
+                  Home Assistant log.",
+                "fields": {}
+            },
+            "reload_core_config": {
+                "description": "Reload the core configuration.",
+                "fields": {}
+            },
+            "restart": {
+                "description": "Restart the Home Assistant service.",
+                "fields": {}
+            },
+            "stop": {
+                "description": "Stop the Home Assistant service.",
+                "fields": {}
+            },
+            "toggle": {
+                "description": "Generic service to toggle devices on/off under\
+                 any domain. Same usage as the light.turn_on, switch.turn_on,\
+                  etc. services.",
+                "fields": {
+                    "entity_id": {
+                        "description": "The entity_id of the device to toggle\
+                         on/off.",
+                        "example": "light.living_room"
+                    }
+                }
+            },
+            "turn_off": {
+                "description": "Generic service to turn devices off under\
+                 any domain.\
+                 Same usage as the light.turn_on, switch.turn_on, etc.\
+                 services.",
+                "fields": {
+                    "entity_id": {
+                        "description": "The entity_id of the device\
+                         to turn off.",
+                        "example": "light.living_room"
+                    }
+                }
+            },
+            "turn_on": {
+                "description": "Generic service to turn devices on under\
+                 any domain.\
+                 Same usage as the light.turn_on, switch.turn_on, etc.\
+                  services.",
+                "fields": {
+                    "entity_id": {
+                        "description": "The entity_id of the device to\
+                         turn on.",
+                        "example": "light.living_room"
+                    }
+                }
+            },
+            "update_entity": {
+                "description": "Force one or more entities to update its data",
+                "fields": {
+                    "entity_id": {
+                        "description": "One or multiple entity_ids to update.\
+                         Can be a list.",
+                        "example": "light.living_room"
+                    }
+                }
+            }
+        }
+    }
+]"""
+
+
+def test_service_list() -> None:
+    """Test services can be listed."""
+    with requests_mock.Mocker() as mock:
+        mock.get(
+            "http://localhost:8123/api/services",
+            text=VALID_INFO,
+            status_code=200,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.cli, ["service", "list"], catch_exceptions=False
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 1
+        assert data[0]['domain'] == 'homeassistant'
+
+
+def test_service_completion() -> None:
+    """Test completion for services."""
+    with requests_mock.Mocker() as mock:
+        mock.get(
+            'http://localhost:8123/api/services',
+            text=VALID_INFO,
+            status_code=200,
+        )
+
+        cfg = Configuration()
+
+        result = autocompletion.services(cfg, "service call", "turn")
+        assert len(result) == 2
+
+        resultdict = dict(result)
+
+        assert "homeassistant.turn_on" in resultdict


### PR DESCRIPTION
Why:

 * want to call services

This change addreses the need by:

 * adds `service call` allowing you to do things like:

   `hass-cli -v service call homeassistant.toggle --arguments entity_id=light.office_light`

 * adds `service list` to get list of services if you do:

   `hass-cli service list`

   but you can also use filters:

   `hass-cli service list 'turn_on'`

   will only return the services that have `turn_on` somewere in their name

   Its a regular expresion so you can go crazy if you want:

   `hass-cli service list 'homeassistant\..*turn`