### PR TITLE
Fixing piping and adding support for output=table

### DIFF
--- a/homeassistant_cli/cli.py
+++ b/homeassistant_cli/cli.py
@@ -132,7 +132,7 @@ def _default_token() -> Optional[str]:
     '--output',
     '-o',
     help="Output format",
-    type=click.Choice(['json', 'yaml']),
+    type=click.Choice(['json', 'yaml', 'table']),
     default='json',
     show_default=True,
 )

--- a/homeassistant_cli/config.py
+++ b/homeassistant_cli/config.py
@@ -20,7 +20,7 @@ class Configuration:
         self.debug = False  # type: bool
 
     def echo(self, msg: str, *args: Optional[Any]) -> None:
-        """Main content message to stdout."""
+        """Put content message to stdout."""
         self.log(msg, *args)
 
     def log(  # pylint: disable=no-self-use

--- a/homeassistant_cli/config.py
+++ b/homeassistant_cli/config.py
@@ -1,6 +1,6 @@
 """Configuration for Home Assistant CLI (hass-cli)."""
 import sys
-from typing import Optional
+from typing import Any, Optional
 
 import click
 import homeassistant_cli.const as const
@@ -18,6 +18,10 @@ class Configuration:
         self.insecure = False  # type: bool
         self.timeout = const.DEFAULT_TIMEOUT  # type: int
         self.debug = False  # type: bool
+
+    def echo(self, msg: str, *args: Optional[Any]) -> None:
+        """Main content message to stdout."""
+        self.log(msg, *args)
 
     def log(  # pylint: disable=no-self-use
         self, msg: str, *args: Optional[str]

--- a/homeassistant_cli/const.py
+++ b/homeassistant_cli/const.py
@@ -9,3 +9,11 @@ DEFAULT_SERVER = 'http://localhost:8123'
 DEFAULT_HASSIO_SERVER = 'http://hassio/homeassistant'
 DEFAULT_TIMEOUT = 5
 DEFAULT_OUTPUT = 'json'  # TODO: Have default be human table relevant output
+
+COLUMNS_DEFAULT = [('ALL', '*')]
+COLUMNS_ENTITIES = [
+    ('ENTITY', 'entity_id'),
+    ('DESCRIPTION', 'attributes.friendly_name'),
+    ('STATE', 'state'),
+]
+COLUMNS_SERVICES = [('DOMAIN', 'domain'), ("SERVICE", "domain.services[*]")]

--- a/homeassistant_cli/plugins/entity.py
+++ b/homeassistant_cli/plugins/entity.py
@@ -29,7 +29,7 @@ def cli(ctx):
 @pass_context
 def get(ctx: Configuration, entity):
     """Get/read entity state from Home Assistant."""
-    _LOGGING.info(helper.format_output(ctx, api.get_state(ctx, entity)))
+    ctx.echo(helper.format_output(ctx, api.get_state(ctx, entity)))
 
 
 @cli.command()
@@ -43,16 +43,16 @@ def delete(ctx: Configuration, entity):
     deleted = api.remove_state(ctx, entity)
 
     if deleted:
-        _LOGGING.info("Entity %s deleted.", entity)
+        ctx.echo("Entity %s deleted.", entity)
     else:
-        _LOGGING.info("Entity %s not found.", entity)
+        ctx.echo("Entity %s not found.", entity)
 
 
 @cli.command('list')
 @pass_context
 def listcmd(ctx):
     """List all state from Home Assistant."""
-    _LOGGING.info(helper.format_output(ctx, api.get_states(ctx)))
+    ctx.echo(helper.format_output(ctx, api.get_states(ctx)))
 
 
 @cli.command()
@@ -90,11 +90,11 @@ def edit(ctx: Configuration, entity, newstate, attributes, merge, json):
         existing_state = api.get_state(ctx, entity)
 
         if existing_state:
-            _LOGGING.info("Existing state found for %s", entity)
+            ctx.echo("Existing state found for %s", entity)
             if merge:
                 wanted_state = existing_state
         else:
-            _LOGGING.info("No existing state found for '%s'", entity)
+            ctx.echo("No existing state found for '%s'", entity)
 
         if attributes:
             attributes_dict = helper.to_attributes(attributes)
@@ -117,7 +117,7 @@ def edit(ctx: Configuration, entity, newstate, attributes, merge, json):
         new = click.edit(existing, extension='.{}'.format(ctx.output))
 
         if new is not None:
-            _LOGGING.info("Updating '%s'", entity)
+            ctx.echo("Updating '%s'", entity)
             if ctx.output == 'yaml':
                 wanted_state = yaml.load(new)
             if ctx.output == 'json':
@@ -125,12 +125,12 @@ def edit(ctx: Configuration, entity, newstate, attributes, merge, json):
 
             api.set_state(ctx, entity, wanted_state)
         else:
-            _LOGGING.info("No edits/changes returned from editor.")
+            ctx.echo("No edits/changes returned from editor.")
             return
 
     _LOGGING.debug("wanted: %s", str(wanted_state))
     result = api.set_state(ctx, entity, wanted_state)
-    _LOGGING.info("Entity %s updated succesfully", entity)
+    ctx.echo("Entity %s updated succesfully", entity)
     _LOGGING.debug("Updated to: %s", result)
 
 
@@ -144,13 +144,13 @@ def toggle(ctx: Configuration, entities):
     """Toggle state for one or more entities in Home Assistant."""
     for entity in entities:
         data = {'entity_id': entity}
-        _LOGGING.info("Toggling %s", entity)
+        ctx.echo("Toggling %s", entity)
         result = api.call_service(ctx, 'homeassistant', 'toggle', data)
 
         if ctx.verbose:
-            _LOGGING.info(helper.format_output(ctx, result))
+            ctx.echo(helper.format_output(ctx, result))
 
-        _LOGGING.info("%s entities reported to be toggled", len(result))
+        ctx.echo("%s entities reported to be toggled", len(result))
 
 
 @cli.command('off')
@@ -163,11 +163,11 @@ def off_cmd(ctx: Configuration, entities):
     """Turn entity off."""
     for entity in entities:
         data = {'entity_id': entity}
-        _LOGGING.info("Toggling %s", entity)
+        ctx.echo("Toggling %s", entity)
         result = api.call_service(ctx, 'homeassistant', 'turn_off', data)
         if ctx.verbose:
-            _LOGGING.info(helper.format_output(ctx, result))
-        _LOGGING.info("%s entities reported to be turned off", len(result))
+            ctx.echo(helper.format_output(ctx, result))
+        ctx.echo("%s entities reported to be turned off", len(result))
 
 
 @cli.command('on')
@@ -180,9 +180,9 @@ def on_cmd(ctx: Configuration, entities):
     """Turn entity on."""
     for entity in entities:
         data = {'entity_id': entity}
-        _LOGGING.info("Toggling %s", entity)
+        ctx.echo("Toggling %s", entity)
         result = api.call_service(ctx, 'homeassistant', 'turn_on', data)
 
         if ctx.verbose:
-            _LOGGING.info(helper.format_output(ctx, result))
-        _LOGGING.info("%s entities reported to be turned on", len(result))
+            ctx.echo(helper.format_output(ctx, result))
+        ctx.echo("%s entities reported to be turned on", len(result))

--- a/homeassistant_cli/plugins/event.py
+++ b/homeassistant_cli/plugins/event.py
@@ -48,4 +48,4 @@ def fire(ctx: Configuration, event, json):
             click.echo("No edits/changes.")
             return
 
-    _LOGGING.info(raw_format_output(ctx.output, response.json()))
+    ctx.echo(raw_format_output(ctx.output, response.json()))

--- a/homeassistant_cli/plugins/info.py
+++ b/homeassistant_cli/plugins/info.py
@@ -14,4 +14,4 @@ _LOGGING = logging.getLogger(__name__)
 @pass_context
 def cli(ctx: Configuration):
     """Get basic info from Home Assistant."""
-    _LOGGING.info(format_output(ctx, api.get_info(ctx)))
+    ctx.echo(format_output(ctx, api.get_info(ctx)))

--- a/homeassistant_cli/plugins/raw.py
+++ b/homeassistant_cli/plugins/raw.py
@@ -26,13 +26,13 @@ def get(ctx: Configuration, method):
 
     if response.text:
         try:
-            _LOGGING.info(
+            ctx.echo(
                 "%s: %s",
                 response.status_code,
                 format_output(ctx, response.json()),
             )
         except json_.decoder.JSONDecodeError:
-            _LOGGING.info("%s: %s", response.status_code, response.text)
+            ctx.echo("%s: %s", response.status_code, response.text)
     else:
         _LOGGING.warning(
             "%s: <No output returned from GET %s>",
@@ -58,13 +58,13 @@ def post(ctx: Configuration, method, json):
 
     if response.text:
         try:
-            _LOGGING.info(
+            ctx.echo(
                 "%s: %s",
                 response.status_code,
                 format_output(ctx, response.json()),
             )
         except json_.decoder.JSONDecodeError:
-            _LOGGING.info("%s: %s", response.status_code, response.text)
+            ctx.echo("%s: %s", response.status_code, response.text)
     else:
         _LOGGING.warning(
             "%s: <No output returned from POST %s>",

--- a/homeassistant_cli/plugins/service.py
+++ b/homeassistant_cli/plugins/service.py
@@ -51,7 +51,7 @@ def list_cmd(ctx: Configuration, servicefilter):
                     domaindata["services"] = servicedata
                     result[domain_name] = domaindata
 
-    _LOGGING.info(format_output(ctx, result))
+    ctx.echo(format_output(ctx, result))
 
 
 @cli.command('call')
@@ -72,6 +72,6 @@ def call(ctx: Configuration, service, arguments):
 
     data = to_attributes(arguments)
 
-    _LOGGING.info(
+    ctx.echo(
         format_output(ctx, api.call_service(ctx, parts[0], parts[1], data))
     )

--- a/homeassistant_cli/plugins/template.py
+++ b/homeassistant_cli/plugins/template.py
@@ -61,4 +61,4 @@ def cli(ctx: Configuration, template, datafile, local: bool) -> None:
     else:
         output = api.render_template(ctx, templatestr, variables)
 
-    _LOGGING.info(output)
+    ctx.echo(output)

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ REQUIRES = [
     'homeassistant',
     'tabulate==0.8.2',
     'idna==2.5',
+    'jsonpath-rw==1.4.0',
 ]
 
 # should be as close to homeassistant dev/master as possible


### PR DESCRIPTION
example:

```
hass-cli --output=table entity toggle light.office_light                                             
ENTITY                          DESCRIPTION    STATE
------------------------------  -------------  -------
group.office_lights_motionview  office lights  on
light.office_light              Office Light   on
```

see more details in commit msgs.