### PR TITLE
Introduce -x flag for showing exceptions

### DIFF
--- a/homeassistant_cli/cli.py
+++ b/homeassistant_cli/cli.py
@@ -29,7 +29,7 @@ def run() -> None:
     over exception handling in Click.
     """
     # a hack to see if exception details should be printed.
-    exceptionflags = ['-v', '--verbose']
+    exceptionflags = ['-x']
     verbose = [c for c in exceptionflags if c in sys.argv]
 
     try:
@@ -118,8 +118,8 @@ def _default_token() -> Optional[str]:
 )
 @click.option(
     '--token',
-    default=_default_token,  # type: ignore
-    help='The Bearer token for Home Assistant instance.',
+    default=_default_token,
+    help='The Bearer token for Home Assistant instance.',  # type: ignore
     envvar='HASS_TOKEN',
 )
 @click.option(
@@ -136,7 +136,20 @@ def _default_token() -> Optional[str]:
     default='json',
     show_default=True,
 )
-@click.option('-v', '--verbose', is_flag=True, help='Enables verbose mode.')
+@click.option(
+    '-v',
+    '--verbose',
+    is_flag=True,
+    default=False,
+    help='Enables verbose mode.',
+)
+@click.option(
+    '-x',
+    'showexceptions',
+    default=False,
+    is_flag=True,
+    help="Print backtraces when exception occurs.",
+)
 @click.option(
     '--insecure',
     is_flag=True,
@@ -162,6 +175,7 @@ def cli(
     timeout: int,
     debug: bool,
     insecure: bool,
+    showexceptions: bool,
 ):
     """Command line interface for Home Assistant."""
     ctx.verbose = verbose
@@ -171,6 +185,7 @@ def cli(
     ctx.output = output
     ctx.debug = debug
     ctx.insecure = insecure
+    ctx.showexceptions = showexceptions
 
     _LOGGER.debug("Using settings: %s", ctx)
 

--- a/homeassistant_cli/config.py
+++ b/homeassistant_cli/config.py
@@ -18,6 +18,7 @@ class Configuration:
         self.insecure = False  # type: bool
         self.timeout = const.DEFAULT_TIMEOUT  # type: int
         self.debug = False  # type: bool
+        self.showexceptions = False  # type: bool
 
     def echo(self, msg: str, *args: Optional[Any]) -> None:
         """Put content message to stdout."""


### PR DESCRIPTION
Why:

 * printing exception backtraces aren't really part of what verbose
   does. Sometimes you want verbose/additional info but not dumping
   of exceptions on "expected" errors - like timeouts.

This change addreses the need by:

 * add a -x flag.