### PR TITLE
WIP: Add shared session + client certificates.

### DIFF
--- a/homeassistant_cli/cli.py
+++ b/homeassistant_cli/cli.py
@@ -2,7 +2,7 @@
 import logging
 import os
 import sys
-from typing import List, Optional, Union, cast
+from typing import List, Optional, Union, cast, no_type_check
 
 import click
 from click.core import Command, Context, Group
@@ -106,6 +106,7 @@ def _default_token() -> Optional[str]:
     return os.environ.get('HASS_TOKEN', os.environ.get('HASSIO_TOKEN', None))
 
 
+@no_type_check
 @click.command(cls=HomeAssistantCli, context_settings=CONTEXT_SETTINGS)
 @click_log.simple_verbosity_option(logging.getLogger(), "--loglevel", "-l")
 @click.version_option(const.__version__)
@@ -119,7 +120,7 @@ def _default_token() -> Optional[str]:
 @click.option(
     '--token',
     default=_default_token,
-    help='The Bearer token for Home Assistant instance.',  # type: ignore
+    help='The Bearer token for Home Assistant instance.',
     envvar='HASS_TOKEN',
 )
 @click.option(
@@ -151,6 +152,12 @@ def _default_token() -> Optional[str]:
     help="Print backtraces when exception occurs.",
 )
 @click.option(
+    '--cert',
+    default=None,
+    envvar="HASS_CERT",
+    help=('Path to client certificate file (.pem) to use when connecting.'),
+)
+@click.option(
     '--insecure',
     is_flag=True,
     default=False,
@@ -176,6 +183,7 @@ def cli(
     debug: bool,
     insecure: bool,
     showexceptions: bool,
+    cert: str,
 ):
     """Command line interface for Home Assistant."""
     ctx.verbose = verbose
@@ -186,6 +194,7 @@ def cli(
     ctx.debug = debug
     ctx.insecure = insecure
     ctx.showexceptions = showexceptions
+    ctx.cert = cert
 
     _LOGGER.debug("Using settings: %s", ctx)
 

--- a/homeassistant_cli/config.py
+++ b/homeassistant_cli/config.py
@@ -19,6 +19,7 @@ class Configuration:
         self.timeout = const.DEFAULT_TIMEOUT  # type: int
         self.debug = False  # type: bool
         self.showexceptions = False  # type: bool
+        self.session = None  # type: Requests.Session
 
     def echo(self, msg: str, *args: Optional[Any]) -> None:
         """Put content message to stdout."""

--- a/homeassistant_cli/config.py
+++ b/homeassistant_cli/config.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 
 import click
 import homeassistant_cli.const as const
+from requests import Session  # noqa: ignore
 
 
 class Configuration:
@@ -19,7 +20,8 @@ class Configuration:
         self.timeout = const.DEFAULT_TIMEOUT  # type: int
         self.debug = False  # type: bool
         self.showexceptions = False  # type: bool
-        self.session = None  # type: Requests.Session
+        self.session = None  # type: Optional[Session]
+        self.cert = None  # type: Optional[str]
 
     def echo(self, msg: str, *args: Optional[Any]) -> None:
         """Put content message to stdout."""

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -43,30 +43,24 @@ def restapi(
     else:
         data_str = json.dumps(data, cls=JSONEncoder)
 
-    headers = {CONTENT_TYPE: hass.CONTENT_TYPE_JSON}  # type: Dict[str, Any]
-    if ctx.token is not None:
-        headers["Authorization"] = "Bearer {}".format(ctx.token)
+    if not ctx.session:
+        ctx.session = requests.Session()
+        headers = {
+            CONTENT_TYPE: hass.CONTENT_TYPE_JSON
+        }  # type: Dict[str, Any]
+
+        if ctx.token is not None:
+            headers["Authorization"] = "Bearer {}".format(ctx.token)
+        ctx.session.headers.update(headers)
+        ctx.session.verify = not ctx.insecure
 
     url = urllib.parse.urljoin(ctx.server, path)
 
     try:
         if method == METH_GET:
-            return requests.get(
-                url,
-                params=data_str,
-                timeout=ctx.timeout,
-                headers=headers,
-                verify=not ctx.insecure,
-            )
+            return requests.get(url, params=data_str)
 
-        return requests.request(
-            method,
-            url,
-            data=data_str,
-            timeout=ctx.timeout,
-            headers=headers,
-            verify=not ctx.insecure,
-        )
+        return requests.request(method, url, data=data_str)
 
     except requests.exceptions.ConnectionError:
         raise HomeAssistantCliError("Error connecting to {}".format(url))

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -53,6 +53,14 @@ def restapi(
             headers["Authorization"] = "Bearer {}".format(ctx.token)
         ctx.session.headers.update(headers)
         ctx.session.verify = not ctx.insecure
+        if ctx.cert:
+            ctx.session.cert = ctx.cert
+
+        _LOGGER.debug(
+            "Session: verify(%s), cert(%s)",
+            ctx.session.verify,
+            ctx.session.cert,
+        )
 
     url = urllib.parse.urljoin(ctx.server, path)
 


### PR DESCRIPTION
shared session works, but not (yet) able to test client certificates.

Please try use this by using this pullrequest and run:

`hass-cli --cert <path.to.pem> info`

and see if it lets you connect.

If not, run again with `-x --debug` flags and paste the content here (
do mask out tokens/pem content before!)