### PR TITLE
Remove bogus aiohttp dependency

### DIFF
--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -12,13 +12,18 @@ import logging
 from typing import Any, Dict, Optional, cast
 import urllib.parse
 
-from aiohttp.hdrs import CONTENT_TYPE, METH_DELETE, METH_GET, METH_POST
 from homeassistant_cli.config import Configuration
 from homeassistant_cli.exceptions import HomeAssistantCliError
 import homeassistant_cli.hassconst as hass
 import requests
 
 _LOGGER = logging.getLogger(__name__)
+
+# copied from aiohttp.hdrs
+CONTENT_TYPE = 'Content-Type'
+METH_DELETE = 'DELETE'
+METH_GET = 'GET'
+METH_POST = 'POST'
 
 
 class APIStatus(enum.Enum):

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ TESTS_REQUIRE = [
     'mypy==0.650',
     'pydocstyle==2.1.1',
     'pylint==2.1.1',
-    'pytest-aiohttp==0.3.0',
     'pytest-cov==2.6.0',
     'pytest-sugar==0.9.2',
     'pytest-timeout==1.3.2',


### PR DESCRIPTION
Why:

 * aiohttp was just used for a few headers.
 * might need it back later for ws integration, but for now its
   just "noise"

This change addreses the need by:

 * remove the aiohttp dependency