### PR TITLE
Include LICENSE.md in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include README.rst
-include LICENSE
+include LICENSE.md
 graft homeassistant_cli
 recursive-exclude * *.py[co]


### PR DESCRIPTION
Otherwise, installing from source fails with `error: [Errno 2] No such file or directory: 'LICENSE.md'`.