### PR TITLE
Include tests in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
 include LICENSE
 graft homeassistant_cli
+graft tests
 recursive-exclude * *.py[co]


### PR DESCRIPTION
This is useful for downstream distributions to test if the package works correctly with their build recipe. Also, it provides a way to test if the dependencies as they are packaged by the distribution are compatible.