### PR TITLE
WIP: Fix bad url creation and don't ignore 401

### DIFF
--- a/homeassistant_cli/plugins/edit.py
+++ b/homeassistant_cli/plugins/edit.py
@@ -83,7 +83,6 @@ def state(ctx: Configuration, entity, newstate, attributes, merge, json):
                 raise ValueError("No new or existing state provided.")
             wanted_state['state'] = existing_state['state']
 
-        print("wanted:", str(wanted_state))
         newjson = raw_format_output('json', wanted_state)
 
         response = req_raw(ctx, 'post', 'states/{}'.format(entity), newjson)

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -54,6 +54,22 @@ def test_info_json() -> None:
         assert VALID_INFO == json.loads(result.output)
 
 
+def test_info_unauth() -> None:
+    """Test info reads properly with json."""
+    with requests_mock.Mocker() as mock:
+        mock.get(
+            'http://localhost:8123/api/discovery_info',
+            json={},
+            status_code=401,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.cli, ['--output=json', 'info'], catch_exceptions=True
+        )
+        assert result.exit_code != 0
+
+
 def test_info_yaml() -> None:
     """Test info reads properly with yaml."""
     with requests_mock.Mocker() as mock:


### PR DESCRIPTION
In #64 it was found that `hass-cli info` would return empty result
when there was 401 auth errors AND for some reason setting HASSIO_TOKEN was not
enough to make use of http://hassio/homeassistant as base url.

401 was easy fix by simply ensuring we will throw
an exception if error occurs + added basic test for this.

Hassio issue was because urljoin was used for combing baseurl with api
path. Now moved to basic string concat so it will work as expected, i.e.

http://hassio/homeassistant + /api/discovery_info gives http://hassio/homeassistant/api/discovery_info

And not http://hassio/api/discovery_info which was the cause of the bugs.