### PR TITLE
upload dist to transfer.sh for trying out build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,22 @@ addons:
   apt:
     packages:
       - libudev-dev
+
+python:
+  - "3.5.3"
+  - "3.6"
+  - "3.7"
+  - "3.8-dev"
+
+env:
+  - TOXENV=lint
+  - TOXENV=pylint
+  - TOXENV=typing
+  - TOXENV=cov
+  - TOXENV=py36
+  - TOXENV=py37
+  - TOXENV=py38
+
 matrix:
   fast_finish: true
   include:
@@ -34,5 +50,15 @@ cache:
     - $HOME/.cache/pip
 install: pip install -U tox coveralls
 language: python
-script: travis_wait 30 tox --develop
+stages:
+    - test
+    - name: transferupload
+      if: env(TOXENV) = py37 AND type IN (push, pull_request)
+jobs:
+  include:
+    - stage: test
+      script: travis_wait 30 tox --develop
+    - stage: transferupload
+      script: script/ephemeral_release
+
 

--- a/script/ephemeral_release
+++ b/script/ephemeral_release
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Builds distribution and pushes to transfer.sh
+# resulting in a ephemaral build
+
+
+cd "$(dirname "$0")/.."
+
+rm -rf dist
+python3 setup.py sdist bdist_wheel
+
+MARKER=${1:-LATEST}
+
+set -x
+ls dist/*.tar.gz | sed -e "s|\(\(.*\).tar.gz\)|curl --uploadfile \1 https://transfer.sh/\2-$MARKER.tar.gz|g"
+set +x


### PR DESCRIPTION
Why:

     * instead of requiring users to setup complete dev environment it would
       be nice to just tall them to do something like:

       `pip3 install https://transfer.sh/qMvNn/PR-24-homeassistant-cli-0.3.0dev.tar.gz`

    This change addreses the need by:

     * added script that runs bdist/wheel and then munges the result
       into transfer.sh and prints out the generated url.

     * Would be better it travis would support annotating pullrequests,
       for now you need to look for it in the build.
       (Asked at
        https://travis-ci.community/t/way-to-update-pull-request-with-link-back-to-build-artifacts-in-public-prs/1387
        for better way)

Fixes #68