### PR TITLE
Add --password flag for providing API password

### DIFF
--- a/homeassistant_cli/autocompletion.py
+++ b/homeassistant_cli/autocompletion.py
@@ -18,6 +18,9 @@ def _init_ctx(ctx: Configuration) -> None:
     if not hasattr(ctx, 'token'):
         ctx.token = os.environ.get('HASS_TOKEN', None)
 
+    if not hasattr(ctx, 'password'):
+        ctx.password = os.environ.get('HASS_PASSWORD', None)
+
     if not hasattr(ctx, 'timeout'):
         ctx.timeout = int(
             os.environ.get('HASS_TIMEOUT', str(const.DEFAULT_TIMEOUT))

--- a/homeassistant_cli/cli.py
+++ b/homeassistant_cli/cli.py
@@ -124,6 +124,12 @@ def _default_token() -> Optional[str]:
     envvar='HASS_TOKEN',
 )
 @click.option(
+    '--password',
+    default=None,
+    help='The API password for Home Assistant instance.',
+    envvar='HASS_PASSWORD',
+)
+@click.option(
     '--timeout',
     help='Timeout for network operations.',
     default=const.DEFAULT_TIMEOUT,
@@ -178,6 +184,7 @@ def cli(
     verbose: bool,
     server: str,
     token: Optional[str],
+    password: Optional[str],
     output: str,
     timeout: int,
     debug: bool,
@@ -189,6 +196,7 @@ def cli(
     ctx.verbose = verbose
     ctx.server = server
     ctx.token = token
+    ctx.password = password
     ctx.timeout = timeout
     ctx.output = output
     ctx.debug = debug

--- a/homeassistant_cli/config.py
+++ b/homeassistant_cli/config.py
@@ -16,6 +16,7 @@ class Configuration:
         self.server = const.DEFAULT_SERVER  # type: str
         self.output = const.DEFAULT_OUTPUT  # type: str
         self.token = None  # type: Optional[str]
+        self.password = None  # type: Optional[str]
         self.insecure = False  # type: bool
         self.timeout = const.DEFAULT_TIMEOUT  # type: int
         self.debug = False  # type: bool
@@ -45,6 +46,7 @@ class Configuration:
         view = {
             "server": self.server,
             "access-token": 'yes' if self.token is not None else 'no',
+            "api-password": 'yes' if self.password is not None else 'no',
             "insecure": self.insecure,
             "output": self.output,
             "verbose": self.verbose,

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -64,6 +64,8 @@ def restapi(
 
     if ctx.token:
         headers["Authorization"] = "Bearer {}".format(ctx.token)
+    if ctx.password:
+        headers["x-ha-access"] = ctx.password
 
     url = urllib.parse.urljoin(ctx.server + path, "")
 


### PR DESCRIPTION
I was not sure if it was right thing to add `HASSIO_PASSWORD` .

Should I add tests for this functionality?