### PR TITLE
Fix autocompletion caused by session/cert fixes

### DIFF
--- a/homeassistant_cli/autocompletion.py
+++ b/homeassistant_cli/autocompletion.py
@@ -27,6 +27,12 @@ def _init_ctx(ctx: Configuration) -> None:
     if not hasattr(ctx, 'insecure'):
         ctx.insecure = False
 
+    if not hasattr(ctx, 'session'):
+        ctx.session = None
+
+    if not hasattr(ctx, 'cert'):
+        ctx.cert = None
+
 
 def services(
     ctx: Configuration, args: str, incomplete: str
@@ -65,7 +71,7 @@ def entities(
     """Entities."""
     _init_ctx(ctx)
     try:
-        response = req(ctx, 'get', 'states')  # type: Dict[str, Any]
+        response = api.get_states(ctx)
     except HTTPError:
         response = {}
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,6 +1,6 @@
 """Tests file for Home Assistant CLI (hass-cli)."""
 import homeassistant_cli.autocompletion as autocompletion
-from homeassistant_cli.config import Configuration
+import homeassistant_cli.cli as cli
 import requests_mock
 
 VALID_INFO = '''[{
@@ -63,7 +63,7 @@ def test_entity_completion() -> None:
             status_code=200,
         )
 
-        cfg = Configuration()
+        cfg = cli.cli.make_context('hass-cli', ['entity', 'get'])
 
         result = autocompletion.entities(cfg, "entity get", "")
         assert len(result) == 3


### PR DESCRIPTION
Why:

 * session and cert attributes was not initialized
  for autocompletion causing errors.

This change addreses the need by:

 * extend the "hack" of adding attributes to context dynamically.