### PR TITLE
feat: add server=auto now uses zeroconf to find HA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ Icon
 
 # pytest
 .cache
+htmlcov 
 
 # GitHub Proposed Python stuff:
 *.py[cod]

--- a/homeassistant_cli/autocompletion.py
+++ b/homeassistant_cli/autocompletion.py
@@ -35,6 +35,11 @@ def _init_ctx(ctx: Configuration) -> None:
     if not hasattr(ctx, 'cert'):
         ctx.cert = None
 
+    if not hasattr(ctx, 'resolved_server'):
+        ctx.resolved_server = os.environ.get(
+            'HASS_SERVER', const.DEFAULT_SERVER
+        )
+
 
 def services(
     ctx: Configuration, args: str, incomplete: str

--- a/homeassistant_cli/cli.py
+++ b/homeassistant_cli/cli.py
@@ -95,13 +95,6 @@ class HomeAssistantCli(click.MultiCommand):
         return cast(Union[Group, Command], mod.cli)
 
 
-def _default_server() -> str:
-    if "HASSIO_TOKEN" in os.environ and "HASS_TOKEN" not in os.environ:
-        return const.DEFAULT_HASSIO_SERVER
-
-    return const.DEFAULT_SERVER
-
-
 def _default_token() -> Optional[str]:
     return os.environ.get('HASS_TOKEN', os.environ.get('HASSIO_TOKEN', None))
 
@@ -113,8 +106,9 @@ def _default_token() -> Optional[str]:
 @click.option(
     '--server',
     '-s',
-    help='The server URL of Home Assistant instance.',
-    default=_default_server,
+    help='The server URL or `auto` for automatic detection',
+    default="auto",
+    show_default=True,
     envvar='HASS_SERVER',
 )
 @click.option(

--- a/homeassistant_cli/const.py
+++ b/homeassistant_cli/const.py
@@ -5,6 +5,7 @@ __version__ = '0.3.0.dev0'
 
 REQUIRED_PYTHON_VER = (3, 5, 3)
 
+AUTO_SERVER = 'auto'
 DEFAULT_SERVER = 'http://localhost:8123'
 DEFAULT_HASSIO_SERVER = 'http://hassio/homeassistant'
 DEFAULT_TIMEOUT = 5

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -12,7 +12,7 @@ import logging
 from typing import Any, Dict, Optional, cast
 import urllib.parse
 
-from homeassistant_cli.config import Configuration
+from homeassistant_cli.config import Configuration, resolve_server
 from homeassistant_cli.exceptions import HomeAssistantCliError
 import homeassistant_cli.hassconst as hass
 import requests
@@ -67,7 +67,7 @@ def restapi(
     if ctx.password:
         headers["x-ha-access"] = ctx.password
 
-    url = urllib.parse.urljoin(ctx.server + path, "")
+    url = urllib.parse.urljoin(resolve_server(ctx) + path, "")
 
     try:
         if method == METH_GET:


### PR DESCRIPTION
Why:

 * when getting started it would be helpful to locate running HA
   servers on local network.

This change addreses the need by:

 * introduce `auto` for server option to activate automatic configuration
   of the server/base url.
 * when `auto` presence of HASSIO_TOKEN will make it use hassio default
   url otherwise use zeroconf to lookup HA on local network.

Fixes #77