### PR TITLE
Add testpypi to master tagged builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,37 +2,46 @@ sudo: false
 addons:
   apt:
     packages:
-      - libudev-dev
+    - libudev-dev
 matrix:
   fast_finish: true
   include:
-    - python: "3.5.3"
-      env: TOXENV=lint
-    - python: "3.5.3"
-      env: TOXENV=pylint
-    - python: "3.5.3"
-      env: TOXENV=typing
-    - python: "3.5.3"
-      env: TOXENV=cov
-      after_success: coveralls
-    - python: "3.6"
-      env: TOXENV=py36
-    - python: "3.7"
-      env: TOXENV=py37
-      dist: xenial
-    - python: "3.8-dev"
-      env: TOXENV=py38
-      dist: xenial
-      if: branch = dev AND type = push
+  - python: 3.5.3
+    env: TOXENV=lint
+  - python: 3.5.3
+    env: TOXENV=pylint
+  - python: 3.5.3
+    env: TOXENV=typing
+  - python: 3.5.3
+    env: TOXENV=cov
+    after_success: coveralls
+  - python: '3.6'
+    env: TOXENV=py36
+  - python: '3.7'
+    env: TOXENV=py37
+    dist: xenial
+  - python: 3.8-dev
+    env: TOXENV=py38
+    dist: xenial
+    if: branch = dev AND type = push
   allow_failures:
-    - python: "3.8-dev"
+    - python: 3.8-dev
       env: TOXENV=py38
       dist: xenial
-
 cache:
   directories:
-    - $HOME/.cache/pip
+  - "$HOME/.cache/pip"
 install: pip install -U tox coveralls
 language: python
 script: travis_wait 30 tox --develop
-
+before_deploy: script/check_release
+deploy:
+  provider: pypi
+  user: maxandersen
+  password:
+    secure: OEeY6YiDndlk9jaIOUdistrHgvZxj61A9Tv/39L5DkHZEloDpvpVhvVVCFS8Obu1M1NSQ9KwDdAT6XvE5UXLdnLK8RSAYoQPoMuZgl1gF1mr561GzGW9lSwRtFt02iaqEko2MCBS0F69ThxsM3AMhMIPClYgQ8OmQsVPLr6TScQg9bFZKdd86zoKkS1Pa/50RQxi9squ0ME1U1uTY1URnQLWoiR91xh2TljCTUReb+gD7oWAvxt4eKmgk4ONj1rX4Rw02n5ADZgX+A7tMUTjg6mNGz6kiKG4xvRRqzaKahZD6x6LuGi2IePS4VMFRVDUGEfQUzdk0xNc7evN+gsMhcjia75U9qtFD85EdtYxIoV3hSKgFvTWn2qhXdTOWqTalrh6ssqL+TLcxbNMrGhYR7XP7uGTzOd2gb8cnU8sNb7UgrTP21qJY+wL9423zS3dMtmzEJShUiKnO0zBi6ZBgfPa2QsmGUYFvDWs4XRCREmyHUaUredbPCthgi7Qi30MLrKPHdmhNX9vc6CCOwVI2kiIFMRIBou2D7WXGm694owtLZHdL4KwTJuOucV1iN3WS4M/4LX45KQBRv38ll6HuRn5JNCDKfQD5FZi1TlKlo4b4Y46yO0RGu1zi9wOJU5idNU9RkqMOOB8iXXzcAz3XlLi+jyrQW0s7X/2VhiXVoc=
+  distributions: sdist bdist_wheel
+  server: https://test.pypi.org/legacy/
+  on:
+    tags: true
+    python: 3.7

--- a/script/check_release
+++ b/script/check_release
@@ -1,0 +1,29 @@
+## check if preconditions are in place to do a release
+
+cd "$(dirname "$0")/.."
+
+# head -n 5 homeassistant_cli/const.py | tail -n 1 | grep PATCH_VERSION > /dev/null
+
+#if [ $? -eq 1 ]
+#then
+#  echo "Patch version not found on const.py line 5"
+#  exit 1
+#fi
+
+head -n 5 homeassistant_cli/const.py | tail -n 1 | grep dev > /dev/null
+
+if [ $? -eq 0 ]
+then
+  echo "Release version should not contain dev tag"
+  exit 1
+fi
+
+CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+
+if [ "$CURRENT_BRANCH" != "master" ] && [ "$CURRENT_BRANCH" != "rc" ]
+then
+  echo "On '$CURRENT_BRANCH' - You have to be on the master or rc branch to release."
+  exit 1
+fi
+
+`

--- a/script/release
+++ b/script/release
@@ -3,30 +3,11 @@
 
 cd "$(dirname "$0")/.."
 
-# head -n 5 homeassistant_cli/const.py | tail -n 1 | grep PATCH_VERSION > /dev/null
-
-#if [ $? -eq 1 ]
-#then
-#  echo "Patch version not found on const.py line 5"
-#  exit 1
-#fi
-
-head -n 5 homeassistant_cli/const.py | tail -n 1 | grep dev > /dev/null
-
-if [ $? -eq 0 ]
-then
-  echo "Release version should not contain dev tag"
-  exit 1
+if ./script/check_release; then
+    rm -rf dist
+    python3 setup.py sdist bdist_wheel
+    python3 -m twine upload dist/* --skip-existing
+else
+    echo "check_release failed. Aborting release."
 fi
 
-CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
-
-if [ "$CURRENT_BRANCH" != "master" ] && [ "$CURRENT_BRANCH" != "rc" ]
-then
-  echo "You have to be on the master or rc branch to release."
-  exit 1
-fi
-
-rm -rf dist
-python3 setup.py sdist bdist_wheel
-python3 -m twine upload dist/* --skip-existing


### PR DESCRIPTION
Why:

 * I don't trust myself in deploying things right all the time.

This change addreses the need by:

 * do an initial setup that automatically deploy to testpypi when
   master is tagged, build passed and check_release passes.
 * when verified to work we can move it to deploy properly to pypi