### PR TITLE
feat(entity): entity list regular filtering

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,13 @@ repos:
     rev: v2.0.0
     hooks:
     - id: flake8
+-   repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: python3 -m pylint.__main__
+        language: system
+        types: [python]
 -   repo: git://github.com/luismayta/pre-commit-mypy
     sha: '0.1.1'  # Use the sha you want to point at
     hooks:

--- a/homeassistant_cli/autocompletion.py
+++ b/homeassistant_cli/autocompletion.py
@@ -40,7 +40,7 @@ def _init_ctx(ctx: Configuration) -> None:
 
 
 def services(
-    ctx: Configuration, args: str, incomplete: str
+    ctx: Configuration, args: List, incomplete: str
 ) -> List[Tuple[str, str]]:
     """Services."""
     _init_ctx(ctx)
@@ -71,7 +71,7 @@ def services(
 
 
 def entities(
-    ctx: Configuration, args: str, incomplete: str
+    ctx: Configuration, args: List, incomplete: str
 ) -> List[Tuple[str, str]]:
     """Entities."""
     _init_ctx(ctx)
@@ -95,7 +95,7 @@ def entities(
 
 
 def events(
-    ctx: Configuration, args: str, incomplete: str
+    ctx: Configuration, args: List, incomplete: str
 ) -> List[Tuple[str, str]]:
     """Events."""
     _init_ctx(ctx)

--- a/homeassistant_cli/cli.py
+++ b/homeassistant_cli/cli.py
@@ -2,7 +2,7 @@
 import logging
 import os
 import sys
-from typing import List, Optional, Union, cast, no_type_check
+from typing import List, Optional, Union, cast
 
 import click
 from click.core import Command, Context, Group
@@ -99,7 +99,6 @@ def _default_token() -> Optional[str]:
     return os.environ.get('HASS_TOKEN', os.environ.get('HASSIO_TOKEN', None))
 
 
-@no_type_check
 @click.command(cls=HomeAssistantCli, context_settings=CONTEXT_SETTINGS)
 @click_log.simple_verbosity_option(logging.getLogger(), "--loglevel", "-l")
 @click.version_option(const.__version__)
@@ -115,7 +114,7 @@ def _default_token() -> Optional[str]:
     '--token',
     default=_default_token,
     help='The Bearer token for Home Assistant instance.',
-    envvar='HASS_TOKEN',
+    envvar='HASS_TOKEN',  # type: ignore
 )
 @click.option(
     '--password',

--- a/homeassistant_cli/plugins/service.py
+++ b/homeassistant_cli/plugins/service.py
@@ -3,7 +3,7 @@
 import logging
 import re as reg
 import sys
-from typing import Any, Dict, Pattern, no_type_check  # noqa: F401
+from typing import Any, Dict, Pattern  # noqa: F401
 
 import click
 import homeassistant_cli.autocompletion as autocompletion
@@ -55,8 +55,7 @@ def list_cmd(ctx: Configuration, servicefilter):
 
 
 @cli.command('call')
-@no_type_check
-@click.argument(
+@click.argument(  # type: ignore
     'service', required=True, autocompletion=autocompletion.services
 )
 @click.option(

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -155,7 +155,7 @@ def get_events(ctx: Configuration) -> Dict[str, Any]:
 
 def get_history(
     ctx: Configuration, entity: Optional[str] = None
-) -> Dict[str, Any]:
+) -> List[Dict[str, Any]]:
     """Return History."""
     try:
         method = hass.URL_API_HISTORY
@@ -171,7 +171,7 @@ def get_history(
         )
 
     if req.status_code == 200:
-        return cast(Dict[str, Any], req.json())
+        return cast(List[Dict[str, Any]], req.json())
 
     raise HomeAssistantCliError(
         "Error while getting all events: {}".format(req.text)

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,6 +1,6 @@
 """Tests file for Home Assistant CLI (hass-cli)."""
 import os
-from typing import Dict, Optional, no_type_check
+from typing import Dict, Optional
 from unittest import mock
 
 import homeassistant_cli.cli as cli
@@ -11,7 +11,6 @@ HASSIO_SERVER_FALLBACK = "http://hassio/homeassistant"
 HASS_SERVER = "http://localhost:8123"
 
 
-@no_type_check
 @pytest.mark.parametrize(
     "description,env,expected_server,expected_resolved_server,\
     expected_token,expected_password",
@@ -82,7 +81,7 @@ def test_defaults(
                 expserver, json={"name": "mock response"}, status_code=200
             )
             ctx = cli.cli.make_context('hass-cli', ['--timeout', '1', 'info'])
-            with ctx:
+            with ctx:  # type: ignore
                 cli.cli.invoke(ctx)
 
             cfg = ctx.obj


### PR DESCRIPTION
Why:

 * list always return everything which gets quite massive.

This change addreses the need by:

 * add `entity list <filter>` support via regular expression.
   Similar to what `service list <filter>` does.
 * Also added mypy to precommit hook setup

Fixes #38