### PR TITLE
autocomplete for raw api

### DIFF
--- a/homeassistant_cli/autocompletion.py
+++ b/homeassistant_cli/autocompletion.py
@@ -2,7 +2,7 @@
 import os
 from typing import Any, Dict, List, Tuple  # NOQA
 
-from homeassistant_cli import const
+from homeassistant_cli import const, hassconst
 from homeassistant_cli.config import Configuration, resolve_server
 import homeassistant_cli.remote as api
 from requests.exceptions import HTTPError
@@ -148,6 +148,24 @@ def table_formats(
         ("textile", "Textile"),
         ("tsv", "Tab Separated Values"),
     ]
+
+    completions.sort()
+
+    return [c for c in completions if incomplete in c[0]]
+
+
+def api_methods(
+    ctx: Configuration, args: List, incomplete: str
+) -> List[Tuple[str, str]]:
+    """Auto completion for methods."""
+    _init_ctx(ctx)
+
+    from inspect import getmembers
+
+    completions = []
+    for name, value in getmembers(hassconst):
+        if name.startswith('URL_API_'):
+            completions.append((value, name[len('URL_API_') :]))
 
     completions.sort()
 

--- a/homeassistant_cli/plugins/raw.py
+++ b/homeassistant_cli/plugins/raw.py
@@ -3,6 +3,7 @@ import json as json_
 import logging
 
 import click
+import homeassistant_cli.autocompletion as autocompletion
 from homeassistant_cli.cli import pass_context
 from homeassistant_cli.config import Configuration
 from homeassistant_cli.helper import format_output
@@ -37,7 +38,9 @@ def _report(ctx, cmd, method, response) -> None:
 
 
 @cli.command()
-@click.argument('method')
+@click.argument(  # type: ignore
+    'method', autocompletion=autocompletion.api_methods
+)
 @pass_context
 def get(ctx: Configuration, method):
     """Do a GET request against api/<method>."""
@@ -47,7 +50,9 @@ def get(ctx: Configuration, method):
 
 
 @cli.command()
-@click.argument('method')
+@click.argument(  # type: ignore
+    'method', autocompletion=autocompletion.api_methods
+)
 @click.option('--json')
 @pass_context
 def post(ctx: Configuration, method, json):

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ norecursedirs = .git testing_config
 
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build
+ignore = E203
 
 [isort]
 # https://github.com/timothycrosley/isort

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -14,8 +14,9 @@ def test_entity_completion(basic_entities_text) -> None:
         )
 
         cfg = cli.cli.make_context('hass-cli', ['entity', 'get'])
-
-        result = autocompletion.entities(cfg, "entity get", "")
+        result = autocompletion.entities(  # type: ignore
+            cfg, ["entity", "get"], ""
+        )
         assert len(result) == 3
 
         resultdict = dict(result)
@@ -35,16 +36,16 @@ def test_service_completion(default_services_text) -> None:
 
         cfg = cli.cli.make_context('hass-cli', ['service', 'get'])
 
-        result = autocompletion.services(cfg, "service get", "")
+        result = autocompletion.services(  # type: ignore
+            cfg, ["service", "get"], ""
+        )
         assert len(result) == 121
 
         resultdict = dict(result)
 
         assert "automation.reload" in resultdict
-        assert (
-            resultdict["automation.reload"]
-            == "Reload the automation configuration."
-        )
+        val = resultdict["automation.reload"]
+        assert val == "Reload the automation configuration."
 
 
 def test_event_completion(default_events_text) -> None:
@@ -58,7 +59,9 @@ def test_event_completion(default_events_text) -> None:
 
         cfg = cli.cli.make_context('hass-cli', ['service', 'get'])
 
-        result = autocompletion.events(cfg, "events get", "")
+        result = autocompletion.events(  # type: ignore
+            cfg, ["events", "get"], ""
+        )
         assert len(result) == 11
 
         resultdict = dict(result)

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -2,7 +2,9 @@
 import json
 
 from click.testing import CliRunner
+import homeassistant_cli.autocompletion as autocompletion
 import homeassistant_cli.cli as cli
+from homeassistant_cli.config import Configuration
 import requests_mock
 
 
@@ -40,3 +42,15 @@ def test_raw_post() -> None:
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data['message'] == 'success'
+
+
+def test_apimethod_completion(default_services) -> None:
+    """Test completion for raw api methods."""
+    cfg = Configuration()
+
+    result = autocompletion.api_methods(cfg, ["raw", "get"], "/api/disc")
+    assert len(result) == 1
+
+    resultdict = dict(result)
+
+    assert "/api/discovery_info" in resultdict


### PR DESCRIPTION
Why:

 * tired of looking up comon api methods

This change addreses the need by:

 * simple 'hack' that will populate completion with the api strings
   found in hassconst.py. Its a nice start.