### PR TITLE
Introduce format=`auto`

### DIFF
--- a/homeassistant_cli/cli.py
+++ b/homeassistant_cli/cli.py
@@ -131,9 +131,9 @@ def _default_token() -> Optional[str]:
 @click.option(
     '--output',
     '-o',
-    help="Output format",
-    type=click.Choice(['json', 'yaml', 'table']),
-    default='json',
+    help="Output format.",
+    type=click.Choice(['json', 'yaml', 'table', 'auto']),
+    default='auto',
     show_default=True,
 )
 @click.option(

--- a/homeassistant_cli/config.py
+++ b/homeassistant_cli/config.py
@@ -155,3 +155,12 @@ class Configuration:
     def resolve_server(self) -> str:
         """Return resolved server (after resolving if needed)."""
         return resolve_server(self)
+
+    def auto_output(self, auto_output: str) -> str:
+        """Configure output format."""
+        if self.output == "auto":
+            if auto_output == 'data':
+                auto_output = const.DEFAULT_DATAOUTPUT
+            _LOGGING.debug("Setting auto-output to: %s", auto_output)
+            self.output = auto_output
+        return self.output

--- a/homeassistant_cli/const.py
+++ b/homeassistant_cli/const.py
@@ -11,6 +11,8 @@ DEFAULT_HASSIO_SERVER = 'http://hassio/homeassistant'
 DEFAULT_TIMEOUT = 5
 DEFAULT_OUTPUT = 'json'  # TODO: Have default be human table relevant output
 
+DEFAULT_DATAOUTPUT = 'yaml'
+
 COLUMNS_DEFAULT = [('ALL', '*')]
 COLUMNS_ENTITIES = [
     ('ENTITY', 'entity_id'),

--- a/homeassistant_cli/helper.py
+++ b/homeassistant_cli/helper.py
@@ -11,6 +11,8 @@ import homeassistant_cli.const as const
 from tabulate import tabulate
 import yaml
 
+_LOGGING = logging.getLogger(__name__)
+
 
 def to_attributes(entry: str) -> Dict[str, str]:
     """Convert list of key=value pairs to dictionary."""
@@ -50,6 +52,10 @@ def raw_format_output(
     table_format: str = 'plain',
 ) -> str:
     """Format the raw output."""
+    if output == 'auto':
+        _LOGGING.debug("Output `auto` thus using %s", const.DEFAULT_DATAOUTPUT)
+        output = const.DEFAULT_DATAOUTPUT
+
     if output == 'json':
         try:
             return json.dumps(data, indent=2, sort_keys=False)

--- a/homeassistant_cli/plugins/config.py
+++ b/homeassistant_cli/plugins/config.py
@@ -10,6 +10,7 @@ import homeassistant_cli.remote as api
 @pass_context
 def cli(ctx):
     """Get configuration from a Home Assistant instance."""
+    ctx.auto_output('table')
 
 
 COLUMNS_DETAILS = [

--- a/homeassistant_cli/plugins/entity.py
+++ b/homeassistant_cli/plugins/entity.py
@@ -20,6 +20,7 @@ _LOGGING = logging.getLogger(__name__)
 @pass_context
 def cli(ctx):
     """Get info and operate on entities from Home Assistant."""
+    ctx.auto_output("table")
 
 
 @cli.command()

--- a/homeassistant_cli/plugins/info.py
+++ b/homeassistant_cli/plugins/info.py
@@ -14,4 +14,4 @@ _LOGGING = logging.getLogger(__name__)
 @pass_context
 def cli(ctx: Configuration):
     """Get basic info from Home Assistant."""
-    ctx.echo(format_output(ctx, api.get_info(ctx)))
+    ctx.echo(format_output(ctx, [api.get_info(ctx)]))

--- a/homeassistant_cli/plugins/raw.py
+++ b/homeassistant_cli/plugins/raw.py
@@ -14,8 +14,9 @@ _LOGGING = logging.getLogger(__name__)
 
 @click.group('raw')
 @pass_context
-def cli(ctx):
+def cli(ctx: Configuration):
     """Call the raw API (advanced)."""
+    ctx.auto_output("data")
 
 
 def _report(ctx, cmd, method, response) -> None:

--- a/homeassistant_cli/plugins/service.py
+++ b/homeassistant_cli/plugins/service.py
@@ -25,6 +25,7 @@ def cli(ctx):
 @pass_context
 def list_cmd(ctx: Configuration, servicefilter):
     """Get list of services."""
+    ctx.auto_output('table')
     services = api.get_services(ctx)
 
     result = {}  # type: Dict[str,Any]
@@ -63,6 +64,7 @@ def list_cmd(ctx: Configuration, servicefilter):
 @pass_context
 def call(ctx: Configuration, service, arguments):
     """Call a service."""
+    ctx.auto_output('data')
     _LOGGING.debug("service call <start>")
     parts = service.split(".")
     if len(parts) != 2:

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -39,7 +39,9 @@ def test_entity_list(basic_entities_text) -> None:
 
         runner = CliRunner()
         result = runner.invoke(
-            cli.cli, ["entity", "list"], catch_exceptions=False
+            cli.cli,
+            ["--output=json", "entity", "list"],
+            catch_exceptions=False,
         )
         assert result.exit_code == 0
         data = json.loads(result.output)
@@ -70,6 +72,15 @@ def test_entity_list_table(
         ["--output=table", "entity", "list"],
         basic_entities_text,
         basic_entities_table_text,
+    )
+
+
+def test_entity_default_list_table(
+    basic_entities_text, basic_entities_table_text
+) -> None:
+    """Test table."""
+    output_formats(
+        ["entity", "list"], basic_entities_text, basic_entities_table_text
     )
 
 
@@ -125,7 +136,9 @@ def test_entity_get(basic_entities_text, basic_entities) -> None:
 
         runner = CliRunner()
         result = runner.invoke(
-            cli.cli, ["entity", "get", "sensor.one"], catch_exceptions=False
+            cli.cli,
+            ["--output=json", "entity", "get", "sensor.one"],
+            catch_exceptions=False,
         )
         assert result.exit_code == 0
 
@@ -159,7 +172,13 @@ def test_entity_edit(basic_entities_text, basic_entities) -> None:
         runner = CliRunner()
         result = runner.invoke(
             cli.cli,
-            ["entity", "edit", "sensor.one", "myspecialstate"],
+            [
+                "--output=json",
+                "entity",
+                "edit",
+                "sensor.one",
+                "myspecialstate",
+            ],
             catch_exceptions=False,
         )
 
@@ -181,7 +200,9 @@ def test_entity_filter(default_entities) -> None:
 
         runner = CliRunner()
         result = runner.invoke(
-            cli.cli, ["entity", "list", "bathroom"], catch_exceptions=False
+            cli.cli,
+            ["--output=json", "entity", "list", "bathroom"],
+            catch_exceptions=False,
         )
         assert result.exit_code == 0
         data = json.loads(result.output)

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -112,7 +112,9 @@ def test_entity_list():
 
         runner = CliRunner()
         result = runner.invoke(
-            cli.cli, ["entity", "list"], catch_exceptions=False
+            cli.cli,
+            ["--output=json", "entity", "list"],
+            catch_exceptions=False,
         )
         assert result.exit_code == 0
         data = json.loads(result.output)
@@ -132,7 +134,7 @@ def test_entity_get() -> None:
         runner = CliRunner()
         result = runner.invoke(
             cli.cli,
-            ["entity", "get", "group.all_remotes"],
+            ["--output=json", "entity", "get", "group.all_remotes"],
             catch_exceptions=False,
         )
         assert result.exit_code == 0

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -51,7 +51,7 @@ def test_info_json() -> None:
             cli.cli, ['--output=json', 'info'], catch_exceptions=False
         )
         assert result.exit_code == 0
-        assert VALID_INFO == json.loads(result.output)
+        assert [VALID_INFO] == json.loads(result.output)
 
 
 def test_info_unauth() -> None:
@@ -84,4 +84,4 @@ def test_info_yaml() -> None:
             cli.cli, ['--output=yaml', 'info'], catch_exceptions=False
         )
         assert result.exit_code == 0
-        assert VALID_INFO == yaml.load(result.output)
+        assert [VALID_INFO] == yaml.load(result.output)

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -19,7 +19,9 @@ def test_raw_get() -> None:
 
         runner = CliRunner()
         result = runner.invoke(
-            cli.cli, ["raw", "get", "/api/anything"], catch_exceptions=False
+            cli.cli,
+            ["--output=json", "raw", "get", "/api/anything"],
+            catch_exceptions=False,
         )
         assert result.exit_code == 0
         data = json.loads(result.output)
@@ -37,7 +39,9 @@ def test_raw_post() -> None:
 
         runner = CliRunner()
         result = runner.invoke(
-            cli.cli, ["raw", "post", "/api/anything"], catch_exceptions=False
+            cli.cli,
+            ["--output=json", "raw", "post", "/api/anything"],
+            catch_exceptions=False,
         )
         assert result.exit_code == 0
         data = json.loads(result.output)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -19,7 +19,9 @@ def test_service_list(default_services) -> None:
 
         runner = CliRunner()
         result = runner.invoke(
-            cli.cli, ["service", "list"], catch_exceptions=False
+            cli.cli,
+            ["--output=json", "service", "list"],
+            catch_exceptions=False,
         )
         assert result.exit_code == 0
         data = json.loads(result.output)
@@ -38,7 +40,7 @@ def test_service_filter(default_services) -> None:
         runner = CliRunner()
         result = runner.invoke(
             cli.cli,
-            ["service", "list", "homeassistant\\.turn.*"],
+            ["--output=json", "service", "list", "homeassistant\\.turn.*"],
             catch_exceptions=False,
         )
         assert result.exit_code == 0
@@ -59,7 +61,7 @@ def test_service_completion(default_services) -> None:
         cfg = Configuration()
 
         result = autocompletion.services(
-            cfg, "service call", "homeassistant.turn"
+            cfg, ["service", "call"], "homeassistant.turn"
         )
         assert len(result) == 2
 
@@ -81,7 +83,7 @@ def test_service_call(default_services) -> None:
         runner = CliRunner()
         result = runner.invoke(
             cli.cli,
-            ["service", "call", "homeassistant.restart"],
+            ["--output=json", "service", "call", "homeassistant.restart"],
             catch_exceptions=False,
         )
 


### PR DESCRIPTION
Why:

 * Not all commands looks better in table format
 * Not all commands looks great in json/yaml format

This change addreses the need by:

 * introduce `auto` format so command/groups can define what they want
 * make entity and other commands use `table` for better look AND
   more like a command line tool for use in pipes.
 * Fix all tests so they are more explict about what format they
   expect.