### PR TITLE
Multiple entities for history period

### DIFF
--- a/homeassistant_cli/helper.py
+++ b/homeassistant_cli/helper.py
@@ -86,6 +86,7 @@ def raw_format_output(
 
             result.append(row)
 
+        # result.sort(key=lambda row: row[3])
         return cast(
             str, tabulate(result, headers=headers, tablefmt=table_format)
         )

--- a/homeassistant_cli/plugins/entity.py
+++ b/homeassistant_cli/plugins/entity.py
@@ -217,7 +217,7 @@ def on_cmd(ctx: Configuration, entities):
 
 @cli.command()
 @click.argument(  # type: ignore
-    'entity', required=False, autocompletion=autocompletion.entities
+    'entities', nargs=-1, required=True, autocompletion=autocompletion.entities
 )
 @click.option(
     '--since',
@@ -234,7 +234,7 @@ def on_cmd(ctx: Configuration, entities):
     expression relative to now. Defaults to now.",
 )
 @pass_context
-def history(ctx: Configuration, entity: str, since: str, end: str):
+def history(ctx: Configuration, entities: List, since: str, end: str):
     """Get history from Home Assistant, all or per entity.
 
     You can use `--since` and `--end` to narrow or expand the time period.
@@ -265,7 +265,7 @@ def history(ctx: Configuration, entity: str, since: str, end: str):
             )
         )
 
-    data = api.get_history(ctx, entity, start_time, end_time)
+    data = api.get_history(ctx, list(entities), start_time, end_time)
 
     result = []  # type: List[Dict[str, Any]]
     entitycount = 0

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -156,7 +156,7 @@ def get_events(ctx: Configuration) -> Dict[str, Any]:
 
 def get_history(
     ctx: Configuration,
-    entity: Optional[str] = None,
+    entities: Optional[List] = None,
     start_time: Optional[datetime] = None,
     end_time: Optional[datetime] = None,
 ) -> List[Dict[str, Any]]:
@@ -169,8 +169,8 @@ def get_history(
 
         params = collections.OrderedDict()  # type: Dict[str, str]
 
-        if entity:
-            params["filter_entity_id"] = entity
+        if entities:
+            params["filter_entity_id"] = ",".join(entities)
         if end_time:
             params["end_time"] = end_time.isoformat()
 


### PR DESCRIPTION
Why:

 * looking in hass source code i noticed /period actually support
   taking a comma separated list.

This change addreses the need by:

 * can now pass in multiple entities for `history`, ex.
   `hass-cli entity history light.kitchen binary_sensor.kitchenmotion`