### PR TITLE
Use from instead of import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 """Setup script for Home Assistant CLI."""
 from datetime import datetime as dt
 
-import homeassistant_cli.const as hass_cli_const
+from homeassistant_cli import const
 from setuptools import find_packages, setup
 
 PROJECT_NAME = 'Home Assistant CLI'
@@ -22,9 +22,7 @@ GITHUB_PATH = '{}/{}'.format(
 )
 GITHUB_URL = 'https://github.com/{}'.format(GITHUB_PATH)
 
-DOWNLOAD_URL = '{}/archive/{}.zip'.format(
-    GITHUB_URL, hass_cli_const.__version__
-)
+DOWNLOAD_URL = '{}/archive/{}.zip'.format(GITHUB_URL, const.__version__)
 PROJECT_URLS = {
     'Bug Reports': '{}/issues'.format(GITHUB_URL),
     'Dev Docs': 'https://developers.home-assistant.io/',
@@ -64,14 +62,14 @@ TESTS_REQUIRE = [
     'wheel==0.32.3',  # Otherwise setup.py bdist_wheel does not work
 ]
 
-MIN_PY_VERSION = '.'.join(map(str, hass_cli_const.REQUIRED_PYTHON_VER))
+MIN_PY_VERSION = '.'.join(map(str, const.REQUIRED_PYTHON_VER))
 
 # Allow you to run pip3 install .[test] to get test dependencies included
 EXTRAS_REQUIRE = {'test': TESTS_REQUIRE}
 
 setup(
     name=PROJECT_PACKAGE_NAME,
-    version=hass_cli_const.__version__,
+    version=const.__version__,
     url=PROJECT_URL,
     download_url=DOWNLOAD_URL,
     project_urls=PROJECT_URLS,

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,11 @@
 """Setup script for Home Assistant CLI."""
 from datetime import datetime as dt
 
-from homeassistant_cli import const
+# from homeassistant_cli import const
 from setuptools import find_packages, setup
+
+REQUIRED_PYTHON_VER = (3, 5, 3)  # const.REQUIRED_PYTHON_VER
+__version__ = '0.4.0.dev0'  # const.__version__
 
 PROJECT_NAME = 'Home Assistant CLI'
 PROJECT_PACKAGE_NAME = 'homeassistant-cli'
@@ -22,7 +25,7 @@ GITHUB_PATH = '{}/{}'.format(
 )
 GITHUB_URL = 'https://github.com/{}'.format(GITHUB_PATH)
 
-DOWNLOAD_URL = '{}/archive/{}.zip'.format(GITHUB_URL, const.__version__)
+DOWNLOAD_URL = '{}/archive/{}.zip'.format(GITHUB_URL, __version__)
 PROJECT_URLS = {
     'Bug Reports': '{}/issues'.format(GITHUB_URL),
     'Dev Docs': 'https://developers.home-assistant.io/',
@@ -62,14 +65,14 @@ TESTS_REQUIRE = [
     'wheel==0.32.3',  # Otherwise setup.py bdist_wheel does not work
 ]
 
-MIN_PY_VERSION = '.'.join(map(str, const.REQUIRED_PYTHON_VER))
+MIN_PY_VERSION = '.'.join(map(str, REQUIRED_PYTHON_VER))
 
 # Allow you to run pip3 install .[test] to get test dependencies included
 EXTRAS_REQUIRE = {'test': TESTS_REQUIRE}
 
 setup(
     name=PROJECT_PACKAGE_NAME,
-    version=const.__version__,
+    version=__version__,
     url=PROJECT_URL,
     download_url=DOWNLOAD_URL,
     project_urls=PROJECT_URLS,


### PR DESCRIPTION
Why:

 * 2019-01-23 or day before builds out of blue started failing in
   importing homeassistant.

This change addreses the need by:

 * use from instead of import.as that seem to work when locally running
   tox - don't know why that is suddenly needed.