### PR TITLE
Multiple entities for history period

### DIFF
--- a/homeassistant_cli/helper.py
+++ b/homeassistant_cli/helper.py
@@ -86,6 +86,7 @@ def raw_format_output(
 
             result.append(row)
 
+        # result.sort(key=lambda row: row[3])
         return cast(
             str, tabulate(result, headers=headers, tablefmt=table_format)
         )

--- a/homeassistant_cli/plugins/entity.py
+++ b/homeassistant_cli/plugins/entity.py
@@ -217,7 +217,7 @@ def on_cmd(ctx: Configuration, entities):
 
 @cli.command()
 @click.argument(  # type: ignore
-    'entity', required=False, autocompletion=autocompletion.entities
+    'entities', nargs=-1, required=True, autocompletion=autocompletion.entities
 )
 @click.option(
     '--since',
@@ -234,7 +234,7 @@ def on_cmd(ctx: Configuration, entities):
     expression relative to now. Defaults to now.",
 )
 @pass_context
-def history(ctx: Configuration, entity: str, since: str, end: str):
+def history(ctx: Configuration, entities: List, since: str, end: str):
     """Get history from Home Assistant, all or per entity.
 
     You can use `--since` and `--end` to narrow or expand the time period.
@@ -265,7 +265,7 @@ def history(ctx: Configuration, entity: str, since: str, end: str):
             )
         )
 
-    data = api.get_history(ctx, entity, start_time, end_time)
+    data = api.get_history(ctx, list(entities), start_time, end_time)
 
     result = []  # type: List[Dict[str, Any]]
     entitycount = 0

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -156,7 +156,7 @@ def get_events(ctx: Configuration) -> Dict[str, Any]:
 
 def get_history(
     ctx: Configuration,
-    entity: Optional[str] = None,
+    entities: Optional[List] = None,
     start_time: Optional[datetime] = None,
     end_time: Optional[datetime] = None,
 ) -> List[Dict[str, Any]]:
@@ -169,8 +169,8 @@ def get_history(
 
         params = collections.OrderedDict()  # type: Dict[str, str]
 
-        if entity:
-            params["filter_entity_id"] = entity
+        if entities:
+            params["filter_entity_id"] = ",".join(entities)
         if end_time:
             params["end_time"] = end_time.isoformat()
 

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,13 @@
 """Setup script for Home Assistant CLI."""
 from datetime import datetime as dt
 
-import homeassistant_cli.const as hass_cli_const
 from setuptools import find_packages, setup
+
+# next two consts is to avoid doing this import that started failing
+# end of january 2019.
+# import homeassistant_cli.const as hass_cli_const
+__VERSION__ = '0.4.0.dev0'
+REQUIRED_PYTHON_VER = (3, 5, 3)
 
 PROJECT_NAME = 'Home Assistant CLI'
 PROJECT_PACKAGE_NAME = 'homeassistant-cli'
@@ -22,9 +27,7 @@ GITHUB_PATH = '{}/{}'.format(
 )
 GITHUB_URL = 'https://github.com/{}'.format(GITHUB_PATH)
 
-DOWNLOAD_URL = '{}/archive/{}.zip'.format(
-    GITHUB_URL, hass_cli_const.__version__
-)
+DOWNLOAD_URL = '{}/archive/{}.zip'.format(GITHUB_URL, __VERSION__)
 PROJECT_URLS = {
     'Bug Reports': '{}/issues'.format(GITHUB_URL),
     'Dev Docs': 'https://developers.home-assistant.io/',
@@ -64,14 +67,14 @@ TESTS_REQUIRE = [
     'wheel==0.32.3',  # Otherwise setup.py bdist_wheel does not work
 ]
 
-MIN_PY_VERSION = '.'.join(map(str, hass_cli_const.REQUIRED_PYTHON_VER))
+MIN_PY_VERSION = '.'.join(map(str, REQUIRED_PYTHON_VER))
 
 # Allow you to run pip3 install .[test] to get test dependencies included
 EXTRAS_REQUIRE = {'test': TESTS_REQUIRE}
 
 setup(
     name=PROJECT_PACKAGE_NAME,
-    version=hass_cli_const.__version__,
+    version=__VERSION__,
     url=PROJECT_URL,
     download_url=DOWNLOAD_URL,
     project_urls=PROJECT_URLS,


### PR DESCRIPTION
Why:

 * looking in hass source code i noticed /period actually support
   taking a comma separated list.

This change addreses the need by:

 * can now pass in multiple entities for `history`, ex.
   `hass-cli entity history light.kitchen binary_sensor.kitchenmotion`