### PR TITLE
Dockerfile tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,9 @@ WORKDIR /usr/src/app
 
 COPY . .
 
-# install build dependencies
-RUN apk add --no-cache --virtual build-dependencies gcc musl-dev
-
-# install home-assistant-cli
-RUN pip3 install --no-cache-dir --editable .
-
-# remove build dependencies
-RUN apk del build-dependencies
+# install build dependencies & home-assistant cli
+RUN apk add --no-cache --virtual build-dependencies gcc musl-dev \
+    && pip3 install --no-cache-dir --editable . \
+    && apk del build-dependencies
 
 ENTRYPOINT ["hass-cli"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 RUN apk add --no-cache --virtual build-dependencies gcc musl-dev
 
 # install home-assistant-cli
-RUN pip3 install --no-cache-dir -e .
+RUN pip3 install --no-cache-dir --editable .
 
 # remove build dependencies
 RUN apk del build-dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,13 @@ WORKDIR /usr/src/app
 
 COPY . .
 
-RUN apk add --no-cache --virtual build-dependencies gcc musl-dev\
-    &&  rm -rf /var/cache/apk/*
+# install build dependencies
+RUN apk add --no-cache --virtual build-dependencies gcc musl-dev
 
+# install home-assistant-cli
 RUN pip3 install --no-cache-dir -e .
+
+# remove build dependencies
+RUN apk del build-dependencies
 
 ENTRYPOINT ["hass-cli"]


### PR DESCRIPTION
* it removes the unneeded command to delete the cache (see http://gliderlabs.viewdocs.io/docker-alpine/usage/)
* it also deletes the build dependencies after home-assistant-cli is installed
* use verbose argument in pip command for better readability

now we have a ~200mb container for a <50kb cli tool... i am still not sure if this is cool ;)