### PR TITLE
WIP: Device, Area and event support

### DIFF
--- a/homeassistant_cli/autocompletion.py
+++ b/homeassistant_cli/autocompletion.py
@@ -170,3 +170,29 @@ def api_methods(
     completions.sort()
 
     return [c for c in completions if incomplete in c[0]]
+
+
+def _quoteifneeded(val: str) -> str:
+    if val and ' ' in val:
+        return '"{}"'.format(val)
+    return val
+
+
+def areas(
+    ctx: Configuration, args: List, incomplete: str
+) -> List[Tuple[str, str]]:
+    """Areas."""
+    _init_ctx(ctx)
+    allareas = api.get_areas(ctx)
+
+    completions = []  # type List[Tuple[str, str]]
+
+    if allareas:
+        for area in allareas:
+            completions.append((_quoteifneeded(area['name']), area['area_id']))
+
+        completions.sort()
+
+        return [c for c in completions if incomplete in c[0]]
+
+    return completions

--- a/homeassistant_cli/hassconst.py
+++ b/homeassistant_cli/hassconst.py
@@ -453,3 +453,12 @@ PRECISION_TENTHS = 0.1
 # Static list of entities that will never be exposed to
 # cloud, alexa, or google_home components
 CLOUD_NEVER_EXPOSED_ENTITIES = ['group.all_locks']
+
+
+# Websocket API
+WS_TYPE_DEVICE_REGISTRY_LIST = 'config/device_registry/list'
+WS_TYPE_AREA_REGISTRY_LIST = 'config/area_registry/list'
+WS_TYPE_AREA_REGISTRY_CREATE = 'config/area_registry/create'
+WS_TYPE_AREA_REGISTRY_DELETE = 'config/area_registry/delete'
+WS_TYPE_AREA_REGISTRY_UPDATE = 'config/area_registry/update'
+WS_TYPE_DEVICE_REGISTRY_UPDATE = 'config/device_registry/update'

--- a/homeassistant_cli/plugins/area.py
+++ b/homeassistant_cli/plugins/area.py
@@ -1,0 +1,132 @@
+"""Area (registry) plugin for Home Assistant CLI (hass-cli)."""
+import logging
+import re
+import sys
+from typing import Any, Dict, List, Pattern  # noqa
+
+import click
+import homeassistant_cli.autocompletion as autocompletion
+from homeassistant_cli.cli import pass_context
+from homeassistant_cli.config import Configuration
+import homeassistant_cli.const as const
+import homeassistant_cli.helper as helper
+import homeassistant_cli.remote as api
+
+_LOGGING = logging.getLogger(__name__)
+
+
+@click.group('area')
+@pass_context
+def cli(ctx):
+    """Get info and operate on areas from Home Assistant (EXPERIMENTAL)."""
+
+
+@cli.command('list')
+@click.argument('areafilter', default=".*", required=False)
+@pass_context
+def listcmd(ctx: Configuration, areafilter: str):
+    """List all areas from Home Assistant."""
+    ctx.auto_output("table")
+
+    areas = api.get_areas(ctx)
+
+    result = []  # type: List[Dict]
+    if areafilter == ".*":
+        result = areas
+    else:
+        areafilterre = re.compile(areafilter)  # type: Pattern
+
+        for device in areas:
+            if areafilterre.search(device['name']):
+                result.append(device)
+
+    cols = [('ID', 'area_id'), ('NAME', 'name')]
+
+    ctx.echo(
+        helper.format_output(
+            ctx, result, columns=ctx.columns if ctx.columns else cols
+        )
+    )
+
+
+@cli.command('create')
+@click.argument('names', nargs=-1, required=True)
+@pass_context
+def create(ctx, names):
+    """Create an area.
+
+    NAMES - one or more area names to create
+    """
+    ctx.auto_output("data")
+
+    for name in names:
+        result = api.create_area(ctx, name)
+
+        ctx.echo(
+            helper.format_output(
+                ctx,
+                [result],
+                columns=ctx.columns if ctx.columns else const.COLUMNS_DEFAULT,
+            )
+        )
+
+
+@cli.command('delete')
+@click.argument(  # type: ignore
+    'names', nargs=-1, required=True, autocompletion=autocompletion.areas
+)
+@pass_context
+def delete(ctx, names):
+    """Delete an area.
+
+    NAMES - one or more area names or id to delete
+    """
+    ctx.auto_output("data")
+    excode = 0
+
+    for name in names:
+        area = api.find_area(ctx, name)
+        if not area:
+            _LOGGING.error("Could not find area with id or name: %s", name)
+            excode = 1
+        else:
+            result = api.delete_area(ctx, area['area_id'])
+
+            ctx.echo(
+                helper.format_output(
+                    ctx,
+                    [result],
+                    columns=ctx.columns
+                    if ctx.columns
+                    else const.COLUMNS_DEFAULT,
+                )
+            )
+
+    if excode != 0:
+        sys.exit(excode)
+
+
+@cli.command('rename')
+@click.argument(  # type: ignore
+    'oldname', required=True, autocompletion=autocompletion.areas
+)
+@click.argument('newname', required=True)
+@pass_context
+def rename(ctx, oldname, newname):
+    """Rename an area."""
+    ctx.auto_output("data")
+
+    area = api.find_area(ctx, oldname)
+    if not area:
+        _LOGGING.error("Could not find area with id or name: %s", oldname)
+        sys.exit(1)
+
+    result = api.rename_area(ctx, area['area_id'], newname)
+
+    ctx.echo(
+        helper.format_output(
+            ctx,
+            [result],
+            columns=ctx.columns if ctx.columns else const.COLUMNS_DEFAULT,
+        )
+    )

--- a/homeassistant_cli/plugins/device.py
+++ b/homeassistant_cli/plugins/device.py
@@ -1,0 +1,127 @@
+"""Device (registry) plugin for Home Assistant CLI (hass-cli)."""
+import logging
+import re
+import sys
+from typing import Any, Dict, List, Optional, Pattern  # noqa
+
+import click
+import homeassistant_cli.autocompletion as autocompletion
+from homeassistant_cli.cli import pass_context
+from homeassistant_cli.config import Configuration
+import homeassistant_cli.helper as helper
+import homeassistant_cli.remote as api
+
+_LOGGING = logging.getLogger(__name__)
+
+
+@click.group('device')
+@pass_context
+def cli(ctx):
+    """Get info and operate on devices from Home Assistant (EXPERIMENTAL)."""
+
+
+@cli.command('list')
+@click.argument('devicefilter', default=".*", required=False)
+@pass_context
+def listcmd(ctx: Configuration, devicefilter: str):
+    """List all devices from Home Assistant."""
+    ctx.auto_output("table")
+
+    devices = api.get_devices(ctx)
+
+    result = []  # type: List[Dict]
+    if devicefilter == ".*":
+        result = devices
+    else:
+        devicefilterre = re.compile(devicefilter)  # type: Pattern
+
+        for device in devices:
+            if devicefilterre.search(device['name']):
+                result.append(device)
+
+    cols = [
+        ('ID', 'id'),
+        ('NAME', 'name'),
+        ('MODEL', 'model'),
+        ('MANUFACTURER', 'manufacturer'),
+        ('AREA', 'area_id'),
+    ]
+
+    ctx.echo(
+        helper.format_output(
+            ctx, result, columns=ctx.columns if ctx.columns else cols
+        )
+    )
+
+
+@cli.command('assign')
+@click.argument(  # type: ignore
+    'area_id_or_name', required=True, autocompletion=autocompletion.areas
+)
+@click.argument('names', nargs=-1, required=False)
+@click.option(
+    '--match', help="Expression used to find devices matching that name"
+)
+@pass_context
+def assign(
+    ctx: Configuration,
+    area_id_or_name,
+    names: List[str],
+    match: Optional[str] = None,
+):
+    """Update area on one or more devices.
+
+    NAMES - one or more name or id (Optional)
+    """
+    ctx.auto_output("data")
+
+    devices = api.get_devices(ctx)
+
+    result = []  # type: List[Dict]
+
+    area = api.find_area(ctx, area_id_or_name)
+    if not area:
+        _LOGGING.error(
+            "Could not find area with id or name: %s", area_id_or_name
+        )
+        sys.exit(1)
+
+    if match:
+        if match == ".*":
+            result = devices
+        else:
+            devicefilterre = re.compile(match)  # type: Pattern
+
+            for device in devices:
+                if devicefilterre.search(device['name']):
+                    result.append(device)
+
+    for id_or_name in names:
+        device = next(  # type: ignore
+            (x for x in devices if x['id'] == id_or_name), None
+        )
+        if not device:
+            device = next(  # type: ignore
+                (x for x in devices if x['name'] == id_or_name), None
+            )
+        if not device:
+            _LOGGING.error(
+                "Could not find device with id or name: %s", id_or_name
+            )
+            sys.exit(1)
+        result.append(device)
+
+    for device in result:
+        output = api.assign_area(ctx, device['id'], area['area_id'])
+        if output['success']:
+            ctx.echo(
+                "Successfully assigned '{}' to '{}'".format(
+                    area['name'], device['name']
+                )
+            )
+        else:
+            _LOGGING.error(
+                "Failed to assign '%s' to '%s'", area['name'], device['name']
+            )
+
+            ctx.echo(str(output))

--- a/homeassistant_cli/plugins/event.py
+++ b/homeassistant_cli/plugins/event.py
@@ -51,3 +51,19 @@ def fire(ctx: Configuration, event, json):
 
     if response:
         ctx.echo(raw_format_output(ctx.output, [response], ctx.yaml()))
+
+
+@cli.command()
+@click.argument('event_type', required=False)
+@pass_context
+def watch(ctx: Configuration, event_type):
+    """Subscribe and print events.
+
+    EVENT-TYPE even type to subscribe to. if empty subscribe to all.
+    """
+    frame = {'type': 'subscribe_events'}
+
+    if event_type:
+        frame['event_type'] = event_type
+
+    api.wsapi(ctx, frame, True)

--- a/homeassistant_cli/yaml.py
+++ b/homeassistant_cli/yaml.py
@@ -8,7 +8,7 @@ from ruamel.yaml.compat import StringIO
 
 def yaml() -> YAML:
     """Return default YAML parser."""
-    yamlp = YAML(typ='rt')
+    yamlp = YAML(typ='safe', pure=True)
     yamlp.preserve_quotes = True
     yamlp.default_flow_style = False
     return yamlp
@@ -27,6 +27,11 @@ def dumpyaml(
     if stream is None:
         inefficient = True
         stream = StringIO()
+    # overriding here to get dumping to
+    # not sort keys.
+    yamlp = YAML()
+    yamlp.indent(mapping=4, sequence=6, offset=3)
+    # yamlp.compact(seq_seq=False, seq_map=False)
     yamlp.dump(data, stream, **kw)
     if inefficient:
         return cast(str, stream.getvalue())

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ REQUIRES = [
     'dateparser==0.7.0',
     'regex==2019.01.24',
     'ruamel.yaml==0.15.85',
+    'aiohttp==3.5.4',
 ]
 
 # Should be as close to Home Assistant dev/master as possible

--- a/tests/fixtures/default_areas.json
+++ b/tests/fixtures/default_areas.json
@@ -1,0 +1,5 @@
+[
+    { "area_id": 1, "name": "Kitchen"},
+    { "area_id": 2, "name": "Kitchen Light"},
+    { "area_id": 3, "name": "Bedroom"}
+]

--- a/tests/fixtures/default_devices.json
+++ b/tests/fixtures/default_devices.json
@@ -1,0 +1,355 @@
+[
+  {
+    "config_entries": [
+      "424ae83a64a54fa8b6b01d71aa7d9b3d"
+    ],
+    "connections": [],
+    "manufacturer": "Sonos",
+    "model": "Play:5",
+    "name": "Kitchen",
+    "sw_version": null,
+    "id": "fa56ea5934f44fa19161bbf2a3d33732",
+    "hub_device_id": null,
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [],
+    "connections": [],
+    "manufacturer": "Philips",
+    "model": "Hue color lamp",
+    "name": "Kitchen table left",
+    "sw_version": "5.105.0.21536",
+    "id": "b6f1087b94c84bc8bbe2a01adbd014d8",
+    "hub_device_id": "3e2f3eaccc0a4dedbbc86c32275e6249",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [],
+    "connections": [],
+    "manufacturer": "Philips",
+    "model": "Hue color lamp",
+    "name": "Kitchen table right",
+    "sw_version": "5.105.0.21536",
+    "id": "921ac3ce2d7948e98ceabdecc295e742",
+    "hub_device_id": "3e2f3eaccc0a4dedbbc86c32275e6249",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [],
+    "connections": [],
+    "manufacturer": "Philips",
+    "model": "Hue color spot",
+    "name": "Kitchen left middle at window",
+    "sw_version": "5.105.0.21536",
+    "id": "1eaf5f51bf464a80b4c17a4f1fad1d8f",
+    "hub_device_id": "3e2f3eaccc0a4dedbbc86c32275e6249",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [],
+    "connections": [],
+    "manufacturer": "Philips",
+    "model": "Hue color spot",
+    "name": "Kitchen front right at fridge",
+    "sw_version": "5.105.0.21536",
+    "id": "c022c2a832194a9aadbc40d39e7d5ee7",
+    "hub_device_id": "3e2f3eaccc0a4dedbbc86c32275e6249",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [],
+    "connections": [],
+    "manufacturer": "Philips",
+    "model": "Hue color spot",
+    "name": "Kitchen left back at hub",
+    "sw_version": "5.105.0.21536",
+    "id": "cabab7fdfc97462f959aec7434989c82",
+    "hub_device_id": "3e2f3eaccc0a4dedbbc86c32275e6249",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [],
+    "connections": [],
+    "manufacturer": "Philips",
+    "model": "Hue color spot",
+    "name": "Kitchen left back at bar",
+    "sw_version": "5.105.0.21536",
+    "id": "a5ffc6e863b1478d8f91b414014138d9",
+    "hub_device_id": "3e2f3eaccc0a4dedbbc86c32275e6249",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [],
+    "connections": [],
+    "manufacturer": "Philips",
+    "model": "Hue color spot",
+    "name": "Kitchen right back at sink",
+    "sw_version": "5.105.0.21536",
+    "id": "63b899e6357d43879a7f356b31c233ae",
+    "hub_device_id": "3e2f3eaccc0a4dedbbc86c32275e6249",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [],
+    "connections": [],
+    "manufacturer": "Philips",
+    "model": "Hue color spot",
+    "name": "Kitchen right middle at oven",
+    "sw_version": "5.105.0.21536",
+    "id": "43e5a30659cd4837b7ecaa5447d8be67",
+    "hub_device_id": "3e2f3eaccc0a4dedbbc86c32275e6249",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [
+      "1a64b7d520ad44fab8622bc4efb64e88"
+    ],
+    "connections": [
+      [
+        "zigbee",
+        "00:17:88:01:00:f0:b1:28"
+      ]
+    ],
+    "manufacturer": "Philips",
+    "model": "LCT003",
+    "name": "Kitchen Light 2",
+    "sw_version": "5.105.0.21536",
+    "id": "f9cad07069c74d519fbe84811c91f1fb",
+    "hub_device_id": "ff7da1f735c14b2f865b33615e359474",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [
+      "1a64b7d520ad44fab8622bc4efb64e88"
+    ],
+    "connections": [
+      [
+        "zigbee",
+        "00:17:88:01:00:f0:b2:c8"
+      ]
+    ],
+    "manufacturer": "Philips",
+    "model": "LCT003",
+    "name": "Kitchen Light 3",
+    "sw_version": "5.105.0.21536",
+    "id": "d02ec64623ae4407a80b903cbc061511",
+    "hub_device_id": "ff7da1f735c14b2f865b33615e359474",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [
+      "1a64b7d520ad44fab8622bc4efb64e88"
+    ],
+    "connections": [
+      [
+        "zigbee",
+        "00:17:88:01:00:f0:b2:f1"
+      ]
+    ],
+    "manufacturer": "Philips",
+    "model": "LCT003",
+    "name": "Kitchen Light 1",
+    "sw_version": "5.105.0.21536",
+    "id": "820c9e511fce42ea92b228c18710aa56",
+    "hub_device_id": "ff7da1f735c14b2f865b33615e359474",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [
+      "1a64b7d520ad44fab8622bc4efb64e88"
+    ],
+    "connections": [
+      [
+        "zigbee",
+        "00:17:88:01:00:f0:ac:69"
+      ]
+    ],
+    "manufacturer": "Philips",
+    "model": "LCT003",
+    "name": "Kitchen Light 5",
+    "sw_version": "5.105.0.21536",
+    "id": "417dd42c0c764765aa29580d77b8b7ad",
+    "hub_device_id": "ff7da1f735c14b2f865b33615e359474",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [
+      "1a64b7d520ad44fab8622bc4efb64e88"
+    ],
+    "connections": [
+      [
+        "zigbee",
+        "00:17:88:01:10:4b:e9:a8"
+      ]
+    ],
+    "manufacturer": "Philips",
+    "model": "LCT007",
+    "name": "Kitchen Table Light 1",
+    "sw_version": "5.105.0.21536",
+    "id": "d379711d01fc47d6aef5b85bd81acba4",
+    "hub_device_id": "ff7da1f735c14b2f865b33615e359474",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [
+      "1a64b7d520ad44fab8622bc4efb64e88"
+    ],
+    "connections": [
+      [
+        "zigbee",
+        "00:17:88:01:10:5d:b9:8f"
+      ]
+    ],
+    "manufacturer": "Philips",
+    "model": "LCT007",
+    "name": "Kitchen Table Light 2",
+    "sw_version": "5.105.0.21536",
+    "id": "a3229ac663734c2cb67c7b13c8a2ba0f",
+    "hub_device_id": "ff7da1f735c14b2f865b33615e359474",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [
+      "1a64b7d520ad44fab8622bc4efb64e88"
+    ],
+    "connections": [
+      [
+        "zigbee",
+        "00:17:88:01:00:f0:aa:eb"
+      ]
+    ],
+    "manufacturer": "Philips",
+    "model": "LCT003",
+    "name": "Kitchen Light 6",
+    "sw_version": "5.105.0.21536",
+    "id": "e20132e0f90942298bdae2340e61c079",
+    "hub_device_id": "ff7da1f735c14b2f865b33615e359474",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [
+      "1a64b7d520ad44fab8622bc4efb64e88"
+    ],
+    "connections": [
+      [
+        "zigbee",
+        "00:17:88:01:00:f0:ad:cf"
+      ]
+    ],
+    "manufacturer": "Philips",
+    "model": "LCT003",
+    "name": "Kitchen Light 4",
+    "sw_version": "5.105.0.21536",
+    "id": "9dd4074e35e546ed8d1a4e630fe07926",
+    "hub_device_id": "ff7da1f735c14b2f865b33615e359474",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [
+      "1a64b7d520ad44fab8622bc4efb64e88"
+    ],
+    "connections": [
+      [
+        "zigbee",
+        "00:17:88:01:02:01:1c:f9"
+      ]
+    ],
+    "manufacturer": "Philips",
+    "model": "SML001",
+    "name": "Kitchen Motion",
+    "sw_version": "6.1.0.18912",
+    "id": "ae8b84e99dbf4a9e94072a1588f29298",
+    "hub_device_id": "ff7da1f735c14b2f865b33615e359474",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [
+      "1a64b7d520ad44fab8622bc4efb64e88"
+    ],
+    "connections": [
+      [
+        "zigbee",
+        "00:17:88:01:10:3e:30:37"
+      ]
+    ],
+    "manufacturer": "Philips",
+    "model": "RWL021",
+    "name": "Kitchen Switch",
+    "sw_version": "5.45.1.16265",
+    "id": "ed7a661b309e4f0093f440b327fb0fd4",
+    "hub_device_id": "ff7da1f735c14b2f865b33615e359474",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [
+      "1a64b7d520ad44fab8622bc4efb64e88"
+    ],
+    "connections": [
+      [
+        "zigbee",
+        "00:17:88:01:10:32:d3:74"
+      ]
+    ],
+    "manufacturer": "Philips",
+    "model": "RWL021",
+    "name": "Kitchen Cupboard Switch",
+    "sw_version": "5.45.1.16265",
+    "id": "2fa6cccbebab476d8e6899899df34b38",
+    "hub_device_id": "ff7da1f735c14b2f865b33615e359474",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [
+      "1a64b7d520ad44fab8622bc4efb64e88"
+    ],
+    "connections": [
+      [
+        "zigbee",
+        "00:15:8d:00:02:75:0d:4b"
+      ]
+    ],
+    "manufacturer": "LUMI",
+    "model": "lumi.sensor_magnet.aq2",
+    "name": "Kitchen Terrace Door",
+    "sw_version": "20161128",
+    "id": "4110ac63ee4f4b9a804fe63f372bb601",
+    "hub_device_id": "ff7da1f735c14b2f865b33615e359474",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [
+      "1a64b7d520ad44fab8622bc4efb64e88"
+    ],
+    "connections": [
+      [
+        "zigbee",
+        "00:0b:57:ff:fe:e8:89:2a"
+      ]
+    ],
+    "manufacturer": "IKEA of Sweden",
+    "model": "TRADFRI transformer 30W",
+    "name": "Kitchen Cupboard Light 2",
+    "sw_version": "1.2.245",
+    "id": "f231511fa73c4634b4236f4b46e2f547",
+    "hub_device_id": "ff7da1f735c14b2f865b33615e359474",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  },
+  {
+    "config_entries": [
+      "1a64b7d520ad44fab8622bc4efb64e88"
+    ],
+    "connections": [
+      [
+        "zigbee",
+        "00:0b:57:ff:fe:e8:a5:da"
+      ]
+    ],
+    "manufacturer": "IKEA of Sweden",
+    "model": "TRADFRI transformer 30W",
+    "name": "Kitchen Cupboard Light 1",
+    "sw_version": "1.2.245",
+    "id": "4168666fad43443d807398d3e407a36b",
+    "hub_device_id": "ff7da1f735c14b2f865b33615e359474",
+    "area_id": "e6ebd3e6f6e04b63a0e4a109b4748584"
+  }
+]

--- a/tests/test_area.py
+++ b/tests/test_area.py
@@ -1,0 +1,42 @@
+"""Testing Area operations."""
+
+import json
+import unittest.mock as mock
+
+from click.testing import CliRunner
+import homeassistant_cli.cli as cli
+
+
+def test_area_list(default_areas) -> None:
+    """Test Area List."""
+    with mock.patch(
+        'homeassistant_cli.remote.get_areas', return_value=default_areas
+    ):
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.cli, ["--output=json", "area", "list"], catch_exceptions=False
+        )
+        assert result.exit_code == 0
+
+        data = json.loads(result.output)
+        assert len(data) == 3
+
+
+def test_area_list_filter(default_areas) -> None:
+    """Test Area List."""
+    with mock.patch(
+        'homeassistant_cli.remote.get_areas', return_value=default_areas
+    ):
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.cli,
+            ["--output=json", "area", "list", "Bed.*"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+
+        data = json.loads(result.output)
+        assert len(data) == 1
+        assert data[0]['name'] == "Bedroom"

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -68,3 +68,25 @@ def test_event_completion(default_events_text) -> None:
 
         assert "component_loaded" in resultdict
         assert resultdict["component_loaded"] == ""
+
+
+def test_area_completion(default_events_text) -> None:
+    """Test completion for Area."""
+    with requests_mock.Mocker() as mock:
+        mock.get(
+            'http://localhost:8123/api/events',
+            text=default_events_text,
+            status_code=200,
+        )
+
+        cfg = cli.cli.make_context('hass-cli', ['events', 'list'])
+
+        result = autocompletion.events(  # type: ignore
+            cfg, ["events", "list"], ""
+        )
+        assert len(result) == 11
+
+        resultdict = dict(result)
+
+        assert "component_loaded" in resultdict
+        assert resultdict["component_loaded"] == ""

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,73 @@
+"""Testing Device operations."""
+
+import json
+import unittest.mock as mock
+
+from click.testing import CliRunner
+import homeassistant_cli.cli as cli
+
+
+def test_device_list(default_devices) -> None:
+    """Test Device List."""
+    with mock.patch(
+        'homeassistant_cli.remote.get_devices', return_value=default_devices
+    ):
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.cli,
+            ["--output=json", "device", "list"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+
+        data = json.loads(result.output)
+        assert len(data) == 23
+
+
+def test_device_list_filter(default_devices) -> None:
+    """Test Device List."""
+    with mock.patch(
+        'homeassistant_cli.remote.get_devices', return_value=default_devices
+    ):
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.cli,
+            ["--output=json", "device", "list", "table"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+
+        data = json.loads(result.output)
+        assert len(data) == 2
+        assert data[0]['name'] == "Kitchen table left"
+        assert data[1]['name'] == "Kitchen table right"
+
+
+def test_device_assign(default_areas, default_devices) -> None:
+    """Test basic device assign."""
+    with mock.patch(
+        'homeassistant_cli.remote.get_devices', return_value=default_devices
+    ):
+        with mock.patch(
+            'homeassistant_cli.remote.get_areas', return_value=default_areas
+        ):
+            with mock.patch(
+                'homeassistant_cli.remote.assign_area',
+                return_value={'success': True},
+            ):
+
+                runner = CliRunner()
+                result = runner.invoke(
+                    cli.cli,
+                    ["device", "assign", "Kitchen", "Kitchen table left"],
+                    catch_exceptions=False,
+                )
+                print(result.output)
+                assert result.exit_code == 0
+                expected = (
+                    "Successfully assigned 'Kitchen'"
+                    " to 'Kitchen table left'\n"
+                )
+                assert result.output == expected

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -17,6 +17,8 @@ DFEAULT_PLUGINS = [
     'service',
     'system',
     'template',
+    'area',
+    'device',
 ]
 DFEAULT_PLUGINS.sort()
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,8 @@ commands =
 deps =
      -r{toxinidir}/requirements_test_all.txt
      -c{toxinidir}/homeassistant_cli/package_constraints.txt
+; delete dist to avoid https://github.com/pypa/setuptools/issues/1678
+commands_pre = /bin/bash -c "rm -rf dist"
 
 [testenv:cov]
 basepython = {env:PYTHON3_PATH:python3}


### PR DESCRIPTION
Why:

 * HA is exposing more and more functionallity tied to Device and
   Area registries. Nice to be able to edit areas especially without
   requiring use of browser UI.
 * Monitoring events can be tedious. Lets have a way to monitor.

This change addreses the need by:

 * add initial basic support of access websocket api.
   Currently no sharing of connection. One connection
   made per request, similar to rest api.
 * Add `device list` and `assign` command for devices.
   - list takes a match/filter similar to `entity list`
     i.e. `hass-cli device list 'Kitchen.*Light'
   - assign takes an area name or id together with
     one or more devices specificed by id/name or match.
     i.e. `device assign "Kitchen" --match "Kitchen" 'Ceiling Lamp' 32342334
 * Autocompletion for area names.
 * fixes for setuptools bug that cause build failures
   when dist folder present.
 * Finally a crude but working `entity watch` that simply just
   listen to event bus and print them out. Takes optional argument
   for event types.