### PR TITLE
Add instructions for homebrew installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ To use homebrew on Mac OSX:
 
 .. code:: bash
 
-   $ brew install hass-cli
+   $ brew install homeassistant-cli
 
 Docker
 -------

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,12 @@ To use latest pre-release from ``dev`` branch:
 
    $ pip install git+https://github.com/home-assistant/home-assistant-cli@dev
 
+To use homebrew on Mac OSX:
+
+.. code:: bash
+
+   $ brew install hass-cli
+
 Docker
 -------
 


### PR DESCRIPTION
The PR for adding this as a formula in homebrew is not yet reviewed nor merged, so I would suggest holding off on this PR until that is complete (it's my first homebrew submission, so I may need to make updates there).

For homebrew users (ie OSX only) all that would be required to install is:
`brew install hass-cli`

Further updates would be automatic for end users via the usual `brew upgrade` process. New hass-cli releases require updates to the formula.

Request issue: #146 
Formula PR: https://github.com/Homebrew/homebrew-core/pull/36915