### PR TITLE
Improve the output (fixes #168)

### DIFF
--- a/homeassistant_cli/plugins/event.py
+++ b/homeassistant_cli/plugins/event.py
@@ -59,7 +59,7 @@ def fire(ctx: Configuration, event, json):
 def watch(ctx: Configuration, event_type):
     """Subscribe and print events.
 
-    EVENT-TYPE even type to subscribe to. if empty subscribe to all.
+    EVENT-TYPE even type to subscribe to. If empty then subscribe to all.
     """
     frame = {'type': 'subscribe_events'}
 

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -89,9 +89,9 @@ def restapi(
 
 def wsapi(
     ctx: Configuration, frame: Dict, wait: bool = False
-) -> Optional[Dict]:
+) -> Optional[str]:
     """Make a call to Home Assistant using the WebSocket API."""
-    async def fetcher() -> Optional[Dict]:
+    async def fetcher() -> Optional[str]:
         """Get the data from the WebSocket API."""
         async with aiohttp.ClientSession() as session:
             async with session.ws_connect(

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -90,12 +90,13 @@ def restapi(
 def wsapi(
     ctx: Configuration, frame: Dict, wait: bool = False
 ) -> Optional[Dict]:
-    """Make a call to Home Assistant using WS API."""
+    """Make a call to Home Assistant using the WebSocket API."""
+
     async def fetcher() -> Optional[Dict]:
+        """Get the data from the WebSocket API."""
         async with aiohttp.ClientSession() as session:
             async with session.ws_connect(
-                resolve_server(ctx) + "/api/websocket"
-            ) as wsconn:
+                    resolve_server(ctx) + "/api/websocket") as wsconn:
 
                 await wsconn.send_str(
                     json.dumps({'type': 'auth', 'access_token': ctx.token})
@@ -113,11 +114,10 @@ def wsapi(
                         break
                     elif msg.type == aiohttp.WSMsgType.TEXT:
                         mydata = json.loads(msg.data)  # type: Dict
-
                         if wait:
-                            print(mydata)
+                            print(json.dumps(mydata))
                         elif mydata['type'] == 'result':
-                            return mydata
+                            return json.dumps(mydata)
         return None
 
     loop = asyncio.get_event_loop()

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -89,10 +89,9 @@ def restapi(
 
 def wsapi(
     ctx: Configuration, frame: Dict, wait: bool = False
-) -> Optional[str]:
-    """Make a call to Home Assistant using the WebSocket API."""
-    async def fetcher() -> Optional[str]:
-        """Get the data from the WebSocket API."""
+) -> Optional[Dict]:
+    """Make a call to Home Assistant using WebSocket API."""
+    async def fetcher() -> Optional[Dict]:
         async with aiohttp.ClientSession() as session:
             async with session.ws_connect(
                     resolve_server(ctx) + "/api/websocket") as wsconn:
@@ -113,10 +112,11 @@ def wsapi(
                         break
                     elif msg.type == aiohttp.WSMsgType.TEXT:
                         mydata = json.loads(msg.data)  # type: Dict
+
                         if wait:
                             print(json.dumps(mydata))
                         elif mydata['type'] == 'result':
-                            return json.dumps(mydata)
+                            return mydata
         return None
 
     loop = asyncio.get_event_loop()

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -91,7 +91,6 @@ def wsapi(
     ctx: Configuration, frame: Dict, wait: bool = False
 ) -> Optional[Dict]:
     """Make a call to Home Assistant using the WebSocket API."""
-
     async def fetcher() -> Optional[Dict]:
         """Get the data from the WebSocket API."""
         async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
```bash
$ hass-cli --output json event watch | jq
{
  "type": "auth_required",
  "ha_version": "0.88.0.dev0"
}
{
  "type": "auth_ok",
  "ha_version": "0.88.0.dev0"
}
{
  "id": 1,
  "type": "result",
  "success": true,
  "result": null
}
{
  "id": 1,
  "type": "event",
  "event": {
```
The default output should not be affected.

```bash
$ hass-cli --output json info
[
  {
    "base_url": "http://127.0.0.1:8123",
    "location_name": "Home",
    "requires_api_password": false,
    "version": "0.88.0.dev0"
  }
]

$ hass-cli --output json info | jq
[
  {
    "base_url": "http://127.0.0.1:8123",
    "location_name": "Home",
    "requires_api_password": false,
    "version": "0.88.0.dev0"
  }
]
```