### PR TITLE
Add support for system health

### DIFF
--- a/homeassistant_cli/plugins/system.py
+++ b/homeassistant_cli/plugins/system.py
@@ -4,6 +4,7 @@ import logging
 import click
 from homeassistant_cli.cli import pass_context
 import homeassistant_cli.remote as api
+from homeassistant_cli.config import Configuration
 
 _LOGGING = logging.getLogger(__name__)
 
@@ -19,3 +20,12 @@ def cli(ctx):
 def log(ctx):
     """Get errors from Home Assistant."""
     click.echo(api.get_raw_error_log(ctx))
+
+
+@cli.command()
+@pass_context
+def health(ctx: Configuration):
+    """Get system health from Home Assistant."""
+    frame = {'type': 'system_health/info'}
+
+    click.echo(api.wsapi(ctx, frame, False))

--- a/homeassistant_cli/plugins/system.py
+++ b/homeassistant_cli/plugins/system.py
@@ -3,8 +3,10 @@ import logging
 
 import click
 from homeassistant_cli.cli import pass_context
-import homeassistant_cli.remote as api
 from homeassistant_cli.config import Configuration
+import homeassistant_cli.const as const
+from homeassistant_cli.helper import format_output
+import homeassistant_cli.remote as api
 
 _LOGGING = logging.getLogger(__name__)
 
@@ -26,6 +28,12 @@ def log(ctx):
 @pass_context
 def health(ctx: Configuration):
     """Get system health from Home Assistant."""
-    frame = {'type': 'system_health/info'}
+    info = api.get_health(ctx)
 
-    click.echo(api.wsapi(ctx, frame, False))
+    ctx.echo(
+        format_output(
+            ctx,
+            [info],
+            columns=ctx.columns if ctx.columns else const.COLUMNS_DEFAULT,
+        )
+    )

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -91,6 +91,8 @@ def wsapi(
     ctx: Configuration, frame: Dict, wait: bool = False
 ) -> Optional[Dict]:
     """Make a call to Home Assistant using WS API."""
+    loop = asyncio.get_event_loop()
+
     async def fetcher() -> Optional[Dict]:
         async with aiohttp.ClientSession() as session:
             async with session.ws_connect(
@@ -120,7 +122,6 @@ def wsapi(
                             return mydata
         return None
 
-    loop = asyncio.get_event_loop()
     result = loop.run_until_complete(fetcher())
     return result
 
@@ -204,6 +205,15 @@ def assign_area(
     }
 
     return cast(Dict[str, Any], wsapi(ctx, frame))
+
+
+def get_health(ctx: Configuration) -> Dict[str, Any]:
+    """Get system Health."""
+    frame = {'type': 'system_health/info'}
+
+    info = cast(Dict[str, Dict[str, Any]], wsapi(ctx, frame))['result']
+
+    return info
 
 
 def get_devices(ctx: Configuration) -> List[Dict[str, Any]]:


### PR DESCRIPTION
Add support for the [System health](https://www.home-assistant.io/components/system_health/) component.

```bash
$ hass-cli system health
{'id': 1, 'type': 'result', 'success': True, 'result': {'homeassistant': {'version': '0.88.0.dev0', 'dev': True, 'hassio': False, 'virtualenv': True, 'python_version': '3.7.2', 'docker': False, 'arch': 'x86_64', 'timezone': 'Europe/Zurich', 'os_name': 'Linux'}, 'lovelace': {'mode': 'storage', 'resources': 0, 'views': 2}}}
```