### PR TITLE
fix: event watch has reliable json output

### DIFF
--- a/homeassistant_cli/const.py
+++ b/homeassistant_cli/const.py
@@ -13,7 +13,7 @@ DEFAULT_OUTPUT = 'json'  # TODO: Have default be human table relevant output
 
 DEFAULT_DATAOUTPUT = 'yaml'
 
-COLUMNS_DEFAULT = [('ALL', '*')]
+COLUMNS_DEFAULT = [('ALL', '$')]
 COLUMNS_ENTITIES = [
     ('ENTITY', 'entity_id'),
     ('DESCRIPTION', 'attributes.friendly_name'),

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -10,7 +10,7 @@ from datetime import datetime
 import enum
 import json
 import logging
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Callable, Dict, List, Optional, cast
 import urllib.parse
 from urllib.parse import urlencode
 
@@ -88,9 +88,17 @@ def restapi(
 
 
 def wsapi(
-    ctx: Configuration, frame: Dict, wait: bool = False
+    ctx: Configuration,
+    frame: Dict,
+    callback: Optional[Callable[[Dict], Any]] = None,
 ) -> Optional[Dict]:
-    """Make a call to Home Assistant using WS API."""
+    """Make a call to Home Assistant using WS API.
+
+    if callback provided will keep listening and call
+    on every message.
+
+    If no callback return data returned.
+    """
     loop = asyncio.get_event_loop()
 
     async def fetcher() -> Optional[Dict]:
@@ -116,8 +124,8 @@ def wsapi(
                     elif msg.type == aiohttp.WSMsgType.TEXT:
                         mydata = json.loads(msg.data)  # type: Dict
 
-                        if wait:
-                            print(mydata)
+                        if callback:
+                            callback(mydata)
                         elif mydata['type'] == 'result':
                             return mydata
         return None


### PR DESCRIPTION
Why:

 * event watch is dumping Dict rather than json
 * event watch is not honoring output formats

This change addreses the need by:

 * add callback mechanism for websocket calls
 * used usual formatter for every message
   Means event watch dumps 1 table per msg.
   Recommended to use --no-headers
 * Made formatting just dump one item when output
   is not actually a list.
 * Only print `event` messages