### PR TITLE
Fixes on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Setup script for Home Assistant CLI."""
 import codecs
-import datetime
 from datetime import datetime as dt
 import os
 import re
@@ -34,27 +33,10 @@ def find_version(*file_paths):
 def get_git_commit_datetime() -> str:
     """Return timestamp from last commit."""
     try:
-        commit_hash = (
-            subprocess.check_output(
-                "git rev-parse HEAD", shell=True, stderr=subprocess.STDOUT
-            )
-            .decode("utf-8")
-            .strip()
+        commit_timestamp = subprocess.check_output(
+            "git show -s --format=%ct", shell=True, stderr=subprocess.STDOUT
         )
-        commit_datetime = (
-            subprocess.check_output(
-                "git show -s --format=%ci " + commit_hash,
-                shell=True,
-                stderr=subprocess.STDOUT,
-            )
-            .decode("utf-8")
-            .strip()
-        )
-        print(commit_datetime)
-        datetime_object = datetime.datetime.strptime(
-            commit_datetime, '%Y-%m-%d %H:%M:%S +%f'
-        )
-        print("{:%Y%m%d%H%M%S}".format(datetime_object))
+        datetime_object = dt.fromtimestamp(int(commit_timestamp))
         return "{:%Y%m%d%H%M%S}".format(datetime_object)
     except subprocess.CalledProcessError as cpe:
         print(cpe.output)
@@ -62,7 +44,6 @@ def get_git_commit_datetime() -> str:
 
 
 __VERSION__ = find_version("homeassistant_cli", "const.py")  # type: ignore
-# Append a suffix to the version for dev builds
 # Append a suffix to the version for dev builds
 if 'dev' in __VERSION__:
     __VERSION__ = '{v}{s}'.format(v=__VERSION__, s=get_git_commit_datetime())


### PR DESCRIPTION
Hello! CLI installation is currently failing because the commit has the following timestamp:

~~~
2019-05-15 08:06:10 -0400
~~~

And it doesn't match the `+` when parsed with format `%Y-%m-%d %H:%M:%S +%f`.

Instead of using `%ci` when calling `git show`, we now use `%ct` which prints a UNIX timestamp (it's much easier to parse). It's also unnecessary to use `rev-parse` to get the hash, as `git show` does this automatically. I've also removed some unused import and `print` statements.