### PR TITLE
feat(plugin): hass-cli raw ws for websocket apis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,13 +74,13 @@ jobs:
   static-check:
     executor:
       name: python
-      tag: 3.5.5-stretch
+      tag: 3.6-stretch
 
     steps:
       - checkout
       - docker-prereqs
       - install-requirements:
-          python: 3.5.5-stretch
+          python: 3.6-stretch
           test: true
 
       - run:
@@ -101,27 +101,27 @@ jobs:
   pre-install-all-requirements:
     executor:
       name: python
-      tag: 3.5.5-stretch
+      tag: 3.6-stretch
 
     steps:
       - checkout
       - docker-prereqs
       - install-requirements:
-          python: 3.5.5-stretch
+          python: 3.6-stretch
           all: true
           test: true
 
   pylint:
     executor:
       name: python
-      tag: 3.5.5-stretch
+      tag: 3.6-stretch
     parallelism: 2
 
     steps:
       - checkout
       - docker-prereqs
       - install-requirements:
-          python: 3.5.5-stretch
+          python: 3.6-stretch
           all: true
           test: true
       - install
@@ -190,12 +190,12 @@ jobs:
   deploy:
     executor:
       name: python
-      tag: 3.5.5-stretch
+      tag: 3.6-stretch
     steps:
       - checkout
       - docker-prereqs
       - install-requirements:
-          python: 3.5.5-stretch
+          python: 3.6-stretch
           test: true
       - install
 
@@ -228,11 +228,6 @@ workflows:
           requires:
             - pre-install-all-requirements
       - pre-test:
-          name: pre-test 3.5.5
-          requires:
-            - static-check
-          python: 3.5.5-stretch
-      - pre-test:
           name: pre-test 3.6
           requires:
             - static-check
@@ -242,11 +237,6 @@ workflows:
           requires:
             - static-check
           python: 3.7-stretch
-      - test:
-          name: test 3.5.5
-          requires:
-            - pre-test 3.5.5
-          python: 3.5.5-stretch
       - test:
           name: test 3.6
           requires:
@@ -265,7 +255,6 @@ workflows:
           requires:
             - test 3.6
             - pylint
-            - test 3.5.5
             - test 3.7
           filters:
             tags:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ addons:
 matrix:
   fast_finish: true
   include:
-  - python: 3.5.3
+  - python: 3.6
     env: TOXENV=lint
-  - python: 3.5.3
+  - python: 3.6
     env: TOXENV=pylint
-  - python: 3.5.3
+  - python: 3.6
     env: TOXENV=typing
-  - python: 3.5.3
+  - python: 3.6
     env: TOXENV=cov
     after_success: coveralls
   - python: '3.6'

--- a/homeassistant_cli/autocompletion.py
+++ b/homeassistant_cli/autocompletion.py
@@ -168,7 +168,25 @@ def api_methods(
     completions = []
     for name, value in getmembers(hassconst):
         if name.startswith('URL_API_'):
-            completions.append((value, name[len('URL_API_'):]))
+            completions.append((value, name[len('URL_API_') :]))
+
+    completions.sort()
+
+    return [c for c in completions if incomplete in c[0]]
+
+
+def wsapi_methods(
+    ctx: Configuration, args: List, incomplete: str
+) -> List[Tuple[str, str]]:
+    """Auto completion for websocket methods."""
+    _init_ctx(ctx)
+
+    from inspect import getmembers
+
+    completions = []
+    for name, value in getmembers(hassconst):
+        if name.startswith('WS_TYPE_'):
+            completions.append((value, name[len('WS_TYPE_') :]))
 
     completions.sort()
 

--- a/homeassistant_cli/config.py
+++ b/homeassistant_cli/config.py
@@ -170,7 +170,8 @@ class Configuration:
     def yaml(self) -> YAML:
         """Create default yaml parser."""
         if self:
-            return yaml.yaml()
+            yaml.yaml()
+        return yaml.yaml()
 
     def yamlload(self, source: str) -> Any:
         """Load YAML from source."""

--- a/homeassistant_cli/yaml.py
+++ b/homeassistant_cli/yaml.py
@@ -9,7 +9,7 @@ from ruamel.yaml.compat import StringIO
 def yaml() -> YAML:
     """Return default YAML parser."""
     yamlp = YAML(typ='safe', pure=True)
-    yamlp.preserve_quotes = True
+    yamlp.preserve_quotes = cast(None, True)
     yamlp.default_flow_style = False
     return yamlp
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifier =
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Topic :: Home Automation

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ __VERSION__ = find_version("homeassistant_cli", "const.py")  # type: ignore
 if 'dev' in __VERSION__:
     __VERSION__ = '{v}{s}'.format(v=__VERSION__, s=get_git_commit_datetime())
 
-REQUIRED_PYTHON_VER = (3, 5, 3)
+REQUIRED_PYTHON_VER = (3, 6, 0)
 
 
 PROJECT_NAME = 'Home Assistant CLI'

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -1,5 +1,7 @@
 """Tests file for Home Assistant CLI (hass-cli)."""
 import json
+import unittest.mock as mocker
+from unittest.mock import ANY
 
 from click.testing import CliRunner
 import requests_mock
@@ -59,3 +61,67 @@ def test_apimethod_completion(default_services) -> None:
     resultdict = dict(result)
 
     assert "/api/discovery_info" in resultdict
+
+
+def test_wsapimethod_completion(default_services) -> None:
+    """Test completion for raw ws API methods."""
+    cfg = Configuration()
+
+    result = autocompletion.wsapi_methods(
+        cfg, ["raw", "get"], "config/device_registry/l"
+    )
+    assert len(result) == 1
+
+    resultdict = dict(result)
+
+    assert "config/device_registry/list" in resultdict
+
+
+def test_raw_ws() -> None:
+    """Test websocket."""
+    with mocker.patch(
+        'homeassistant_cli.remote.wsapi', return_value={"result": "worked"}
+    ) as mockmethod:
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.cli,
+            ["--output=json", "raw", "ws", "config/wsmethod"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+
+        mockmethod.assert_called_once()
+        mockmethod.assert_called_with(ANY, {"type": "config/wsmethod"})
+
+        data = json.loads(result.output)
+        assert len(data) == 1
+
+
+def test_raw_ws_data() -> None:
+    """Test websocket with data."""
+    with mocker.patch(
+        'homeassistant_cli.remote.wsapi', return_value={"result": "worked"}
+    ) as mockmethod:
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.cli,
+            [
+                "--output=json",
+                "raw",
+                "ws",
+                "config/wsmethod",
+                "--json",
+                '{ "id":"secret"}',
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+
+        mockmethod.assert_called_with(
+            ANY, {"type": "config/wsmethod", "id": "secret"}
+        )
+
+        data = json.loads(result.output)
+        assert len(data) == 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38, lint, pylint, typing, cov
+envlist = py36, py37, py38, lint, pylint, typing, cov
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Why:

 * testing out websocket apis before there are commands for it
   are tedious. would be nice to have ability like `raw get` to
   access websocket api.

This change addreses the need by:

 * introduce `hass-cli raw ws <method> --json <optional data>` command.
   Example:
   ```
   hass-cli raw ws config/area_registry/delete --json='{ "area_id":"2c8bf93c8082492f99c989896962f207" }'
   ```

Resolves: