### PR TITLE
feat: drop python 3.5 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,13 +74,13 @@ jobs:
   static-check:
     executor:
       name: python
-      tag: 3.5.5-stretch
+      tag: 3.6-stretch
 
     steps:
       - checkout
       - docker-prereqs
       - install-requirements:
-          python: 3.5.5-stretch
+          python: 3.6-stretch
           test: true
 
       - run:
@@ -101,27 +101,27 @@ jobs:
   pre-install-all-requirements:
     executor:
       name: python
-      tag: 3.5.5-stretch
+      tag: 3.6-stretch
 
     steps:
       - checkout
       - docker-prereqs
       - install-requirements:
-          python: 3.5.5-stretch
+          python: 3.6-stretch
           all: true
           test: true
 
   pylint:
     executor:
       name: python
-      tag: 3.5.5-stretch
+      tag: 3.6-stretch
     parallelism: 2
 
     steps:
       - checkout
       - docker-prereqs
       - install-requirements:
-          python: 3.5.5-stretch
+          python: 3.6-stretch
           all: true
           test: true
       - install
@@ -190,12 +190,12 @@ jobs:
   deploy:
     executor:
       name: python
-      tag: 3.5.5-stretch
+      tag: 3.6-stretch
     steps:
       - checkout
       - docker-prereqs
       - install-requirements:
-          python: 3.5.5-stretch
+          python: 3.6-stretch
           test: true
       - install
 
@@ -228,11 +228,6 @@ workflows:
           requires:
             - pre-install-all-requirements
       - pre-test:
-          name: pre-test 3.5.5
-          requires:
-            - static-check
-          python: 3.5.5-stretch
-      - pre-test:
           name: pre-test 3.6
           requires:
             - static-check
@@ -242,11 +237,6 @@ workflows:
           requires:
             - static-check
           python: 3.7-stretch
-      - test:
-          name: test 3.5.5
-          requires:
-            - pre-test 3.5.5
-          python: 3.5.5-stretch
       - test:
           name: test 3.6
           requires:
@@ -265,7 +255,6 @@ workflows:
           requires:
             - test 3.6
             - pylint
-            - test 3.5.5
             - test 3.7
           filters:
             tags:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ addons:
 matrix:
   fast_finish: true
   include:
-  - python: 3.5.3
+  - python: 3.6
     env: TOXENV=lint
-  - python: 3.5.3
+  - python: 3.6
     env: TOXENV=pylint
-  - python: 3.5.3
+  - python: 3.6
     env: TOXENV=typing
-  - python: 3.5.3
+  - python: 3.6
     env: TOXENV=cov
     after_success: coveralls
   - python: '3.6'

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifier =
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Topic :: Home Automation

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ __VERSION__ = find_version("homeassistant_cli", "const.py")  # type: ignore
 if 'dev' in __VERSION__:
     __VERSION__ = '{v}{s}'.format(v=__VERSION__, s=get_git_commit_datetime())
 
-REQUIRED_PYTHON_VER = (3, 5, 3)
+REQUIRED_PYTHON_VER = (3, 6, 0)
 
 
 PROJECT_NAME = 'Home Assistant CLI'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38, lint, pylint, typing, cov
+envlist = py36, py37, py38, lint, pylint, typing, cov
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Why:

 * HomeAssistant dropped python 3.5, no need for us to sustain more pain.

This change addreses the need by:

 * Remove all references to python 3.5 in travis, circle and setup.*
   files.