### PR TITLE
Raise HomeAssistantCliError on auth errors

### DIFF
--- a/homeassistant_cli/plugins/event.py
+++ b/homeassistant_cli/plugins/event.py
@@ -8,6 +8,7 @@ import click
 import homeassistant_cli.autocompletion as autocompletion
 from homeassistant_cli.cli import pass_context
 from homeassistant_cli.config import Configuration
+from homeassistant_cli.exceptions import HomeAssistantCliError
 from homeassistant_cli.helper import format_output, raw_format_output
 import homeassistant_cli.remote as api
 
@@ -78,6 +79,8 @@ def watch(ctx: Configuration, event_type):
                     columns=ctx.columns if ctx.columns else cols,
                 )
             )
+        elif msg['type'] == 'auth_invalid':
+            raise HomeAssistantCliError(msg.get('message'))
 
     if event_type:
         frame['event_type'] = event_type

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -129,6 +129,8 @@ def wsapi(
                             callback(mydata)
                         elif mydata['type'] == 'result':
                             return mydata
+                        elif mydata['type'] == 'auth_invalid':
+                            raise HomeAssistantCliError(mydata.get('message'))
         return None
 
     result = loop.run_until_complete(fetcher())


### PR DESCRIPTION
Currently if an auth error occurs (e.g. if one has not configured any auth info at all on command line or env), commands just exit with successful exit status without outputting anything. This makes them blow up visibly.